### PR TITLE
Allow overriding version via ldflags

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ cd lazyspeed
 go mod download
 ```
 
-3. Build the application:
+3. Build the application (setting version and build date via `ldflags`):
 ```bash
-go build -o lazyspeed
+go build -ldflags "-X main.Version=$(git describe --tags --always) -X main.BuildDate=$(date -u +%Y-%m-%d)" -o lazyspeed
 ```
 
 ## Usage

--- a/model/model.go
+++ b/model/model.go
@@ -80,7 +80,7 @@ func (m *Model) PerformSpeedTest(updateChan chan<- ProgressUpdate) error {
 		return serverList[i].Latency < serverList[j].Latency
 	})
 	server := serverList[0]
-	sendUpdate(0.15, fmt.Sprintf("Selected server: %s with latency %.2f ms", server.Name, server.Latency), updateChan)
+	sendUpdate(0.15, fmt.Sprintf("Selected server: %s with latency %.2f ms", server.Name, server.Latency.Seconds()*1000), updateChan)
 	sendUpdate(0.2, fmt.Sprintf("Selected server: %s", server.Name), updateChan)
 
 	sendUpdate(0.3, "Measuring ping and jitter...", updateChan)

--- a/version.go
+++ b/version.go
@@ -2,11 +2,25 @@ package main
 
 import "fmt"
 
-const (
-	Version   = "0.1.2_8"
-	BuildDate = "2025-02-24" // TODO: This should ideally be set during build time
+var (
+	// Version holds the current version of the application. It can be overridden at
+	// build time using ldflags.
+	Version = "dev"
+	// BuildDate stores the date the binary was built. It can be set at build time
+	// using ldflags.
+	BuildDate string
 )
 
+// GetVersionInfo returns a formatted version string. If BuildDate is empty, the
+// build date is omitted. If Version is empty, it defaults to "dev".
 func GetVersionInfo() string {
-	return fmt.Sprintf("lazyspeed version %s (built: %s)", Version, BuildDate)
+	v := Version
+	if v == "" {
+		v = "dev"
+	}
+
+	if BuildDate == "" {
+		return fmt.Sprintf("lazyspeed version %s", v)
+	}
+	return fmt.Sprintf("lazyspeed version %s (built: %s)", v, BuildDate)
 }


### PR DESCRIPTION
## Summary
- replace version constants with variables so they can be set via ldflags
- document how to build with `-ldflags` to supply `Version` and `BuildDate`
- handle missing build info gracefully and fix latency formatting to satisfy `go vet`

## Testing
- `go vet ./...`
- `go test ./...`
- `go build -ldflags "-X main.Version=test -X main.BuildDate=2024-01-01" ./...`


------
https://chatgpt.com/codex/tasks/task_e_68969c4febbc83268b5f33654d113918