### PR TITLE
feat: Implement server selection functionality

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,12 +38,21 @@ func (s *speedTest) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "q", "ctrl+c":
-			s.quitting = true
-			return s, tea.Quit
-		case "n":
-			if !s.model.Testing {
+		if s.model.SelectingServer {
+			switch msg.String() {
+			case "q", "ctrl+c":
+				s.quitting = true
+				return s, tea.Quit
+			case "up", "k":
+				if s.model.Cursor > 0 {
+					s.model.Cursor--
+				}
+			case "down", "j":
+				if s.model.Cursor < len(s.model.ServerList)-1 {
+					s.model.Cursor++
+				}
+			case "enter":
+				s.model.SelectingServer = false
 				s.model.Testing = true
 				s.model.Progress = 0
 				s.model.CurrentPhase = "Starting speed test..."
@@ -52,7 +61,8 @@ func (s *speedTest) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				s.progressChan = make(chan model.ProgressUpdate)
 				s.errChan = make(chan error, 1)
 				go func() {
-					err := s.model.PerformSpeedTest(s.progressChan)
+					server := s.model.ServerList[s.model.Cursor]
+					err := s.model.PerformSpeedTest(server, s.progressChan)
 					s.errChan <- err
 					close(s.progressChan)
 				}()
@@ -62,8 +72,19 @@ func (s *speedTest) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					waitForProgress(s.progressChan, s.errChan),
 				)
 			}
-		case "h":
-			s.model.ShowHelp = !s.model.ShowHelp
+		} else {
+			switch msg.String() {
+			case "q", "ctrl+c":
+				s.quitting = true
+				return s, tea.Quit
+			case "n":
+				if !s.model.Testing && !s.model.SelectingServer {
+					s.model.SelectingServer = true
+					s.model.ShowHelp = false
+				}
+			case "h":
+				s.model.ShowHelp = !s.model.ShowHelp
+			}
 		}
 
 	case tea.WindowSizeMsg:
@@ -103,27 +124,28 @@ func (s *speedTest) View() string {
 	var b strings.Builder
 
 	b.WriteString("\n")
-
 	b.WriteString(ui.RenderTitle(s.model.Width))
 	b.WriteString("\n\n")
 
-	if s.model.Testing {
+	if s.model.SelectingServer {
+		b.WriteString(ui.RenderServerSelection(s.model, s.model.Width))
+	} else if s.model.Testing {
 		b.WriteString(ui.RenderSpinner(s.spinner, s.model.Width, s.model.CurrentPhase, s.model.Progress))
 		b.WriteString("\n\n")
-	}
+	} else {
+		if s.model.Results != nil || len(s.model.TestHistory) > 0 {
+			b.WriteString(ui.RenderResults(s.model, s.model.Width))
+			b.WriteString("\n")
+		}
 
-	if s.model.Results != nil || len(s.model.TestHistory) > 0 {
-		b.WriteString(ui.RenderResults(s.model, s.model.Width))
-		b.WriteString("\n")
-	}
+		if s.model.Error != nil {
+			b.WriteString("\n")
+			b.WriteString(ui.RenderError(s.model.Error, s.model.Width))
+		}
 
-	if s.model.Error != nil {
-		b.WriteString("\n")
-		b.WriteString(ui.RenderError(s.model.Error, s.model.Width))
-	}
-
-	if s.model.ShowHelp {
-		b.WriteString(ui.RenderHelp(s.model.Width))
+		if s.model.ShowHelp {
+			b.WriteString(ui.RenderHelp(s.model.Width))
+		}
 	}
 
 	b.WriteString("\n")
@@ -151,8 +173,14 @@ func main() {
 		os.Exit(0)
 	}
 
+	m := model.NewModel()
+	if err := m.FetchServerList(); err != nil {
+		fmt.Printf("Error fetching server list: %v\n", err)
+		os.Exit(1)
+	}
+
 	s := speedTest{
-		model:   model.NewModel(),
+		model:   m,
 		spinner: ui.DefaultSpinner,
 	}
 

--- a/model/model.go
+++ b/model/model.go
@@ -25,25 +25,30 @@ type SpeedTestResult struct {
 }
 
 type Model struct {
-	Results       *SpeedTestResult
-	TestHistory   []*SpeedTestResult
-	Testing       bool
-	Progress      float64
-	CurrentPhase  string
-	Error         error
-	ShowHelp      bool
-	Width, Height int
-	PingResults   []float64 // Used for jitter calculation
+	Results         *SpeedTestResult
+	TestHistory     []*SpeedTestResult
+	Testing         bool
+	Progress        float64
+	CurrentPhase    string
+	Error           error
+	ShowHelp        bool
+	Width, Height   int
+	PingResults     []float64 // Used for jitter calculation
+	ServerList      speedtest.Servers
+	SelectingServer bool
+	Cursor          int
 }
 
 func NewModel() *Model {
 	return &Model{
-		Results:      nil,
-		TestHistory:  make([]*SpeedTestResult, 0),
-		Testing:      false,
-		Progress:     0,
-		CurrentPhase: "",
-		ShowHelp:     true,
+		Results:         nil,
+		TestHistory:     make([]*SpeedTestResult, 0),
+		Testing:         false,
+		Progress:        0,
+		CurrentPhase:    "",
+		ShowHelp:        true,
+		SelectingServer: false,
+		Cursor:          0,
 	}
 }
 
@@ -56,7 +61,22 @@ func sendUpdate(progress float64, phase string, updateChan chan<- ProgressUpdate
 	}
 }
 
-func (m *Model) PerformSpeedTest(updateChan chan<- ProgressUpdate) error {
+func (m *Model) FetchServerList() error {
+	m.CurrentPhase = "Fetching server list..."
+	serverList, err := speedtest.FetchServers()
+	if err != nil {
+		return fmt.Errorf("failed to fetch servers: %v", err)
+	}
+	sort.Slice(serverList, func(i, j int) bool {
+		return serverList[i].Latency < serverList[j].Latency
+	})
+	m.ServerList = serverList
+	m.CurrentPhase = ""
+	return nil
+}
+
+func (m *Model) PerformSpeedTest(server *speedtest.Server, updateChan chan<- ProgressUpdate) error {
+	var err error
 	m.Testing = true
 	m.Progress = 0
 	m.Error = nil
@@ -64,24 +84,7 @@ func (m *Model) PerformSpeedTest(updateChan chan<- ProgressUpdate) error {
 	m.PingResults = make([]float64, 0)
 
 	sendUpdate(0.0, "Initializing speed test...", updateChan)
-
-	sendUpdate(0.1, "Finding closest server...", updateChan)
-	serverList, err := speedtest.FetchServers()
-	if err != nil {
-		return fmt.Errorf("failed to fetch servers: %v", err)
-	}
-
-	if len(serverList) == 0 {
-		return fmt.Errorf("no servers available")
-	}
-
-	// Find the closest server
-	sort.Slice(serverList, func(i, j int) bool {
-		return serverList[i].Latency < serverList[j].Latency
-	})
-	server := serverList[0]
-	sendUpdate(0.15, fmt.Sprintf("Selected server: %s with latency %.2f ms", server.Name, server.Latency.Seconds()*1000), updateChan)
-	sendUpdate(0.2, fmt.Sprintf("Selected server: %s", server.Name), updateChan)
+	sendUpdate(0.2, fmt.Sprintf("Testing with server: %s", server.Name), updateChan)
 
 	sendUpdate(0.3, "Measuring ping and jitter...", updateChan)
 	var sumPing float64

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -132,10 +132,29 @@ func RenderError(err error, width int) string {
 func RenderHelp(width int) string {
 	help := strings.Builder{}
 	help.WriteString("\n")
-	help.WriteString("Press 'n' to start a new test\n")
-	help.WriteString("Press 'h' to toggle help\n")
-	help.WriteString("Press 'q' to quit\n")
+	help.WriteString("Controls:\n")
+	help.WriteString("  n: New Test\n")
+	help.WriteString("  h: Toggle Help\n")
+	help.WriteString("  q: Quit\n")
+	help.WriteString("\nIn Server Selection:\n")
+	help.WriteString("  ↑/↓, j/k: Navigate\n")
+	help.WriteString("  Enter: Select Server\n")
 
 	return lipgloss.PlaceHorizontal(width, lipgloss.Center,
 		helpStyle.Render(help.String()))
+}
+
+func RenderServerSelection(m *model.Model, width int) string {
+	var b strings.Builder
+	b.WriteString("Select a server:\n\n")
+
+	for i, server := range m.ServerList {
+		if m.Cursor == i {
+			b.WriteString(fmt.Sprintf("> %s (%s) - %.2f ms\n", server.Name, server.Country, server.Latency.Seconds()*1000))
+		} else {
+			b.WriteString(fmt.Sprintf("  %s (%s) - %.2f ms\n", server.Name, server.Country, server.Latency.Seconds()*1000))
+		}
+	}
+
+	return lipgloss.PlaceHorizontal(width, lipgloss.Center, infoStyle.Render(b.String()))
 }


### PR DESCRIPTION
This commit introduces the ability for you to select a server before running a speed test.

- The application now fetches a list of available servers on startup.
- A new server selection screen is presented to you when you initiate a test.
- You can navigate the server list using the arrow keys and select a server with the 'enter' key.
- The speed test is then performed using the selected server.
- The help text has been updated to reflect the new controls.