### PR TITLE
🧪 Add tests for RenderError

### DIFF
--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -1,0 +1,49 @@
+package ui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRenderError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		width    int
+		wantIn   string
+		wantZero bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			width:    100,
+			wantZero: true,
+		},
+		{
+			name:     "actual error",
+			err:      errors.New("connection timeout"),
+			width:    100,
+			wantIn:   "❌ Error: connection timeout",
+			wantZero: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RenderError(tt.err, tt.width)
+			if tt.wantZero {
+				if got != "" {
+					t.Errorf("RenderError() = %q, want empty string", got)
+				}
+			} else {
+				if got == "" {
+					t.Errorf("RenderError() = empty string, want non-empty")
+				}
+				if !strings.Contains(got, tt.wantIn) {
+					t.Errorf("RenderError() = %q, want string containing %q", got, tt.wantIn)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was testing the `RenderError` function in `ui/ui.go`.
📊 **Coverage:** Covered both `nil` and non-nil error inputs to ensure appropriate outputs (empty string and correctly formatted error message respectively). Used table-driven testing pattern.
✨ **Result:** The `RenderError` function now has 100% test coverage for its different branches, allowing confident refactoring.

---
*PR created automatically by Jules for task [2898872926777463773](https://jules.google.com/task/2898872926777463773) started by @jkleinne*