### PR TITLE
🔒 Fix Index Out of Bounds vulnerability in server selection

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,6 +52,12 @@ func (s *speedTest) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					s.model.Cursor++
 				}
 			case "enter":
+				if s.model.Cursor < 0 || s.model.Cursor >= len(s.model.ServerList) {
+					s.model.Error = fmt.Errorf("invalid server selection")
+					s.model.SelectingServer = false
+					s.model.ShowHelp = false
+					return s, nil
+				}
 				s.model.SelectingServer = false
 				s.model.Testing = true
 				s.model.Progress = 0


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is an Index Out of Bounds panic that could occur in `main.go` around line 64. When a user presses "enter" during server selection, the code was directly accessing `s.model.ServerList[s.model.Cursor]` without validating the length of `ServerList` or the bounds of `Cursor`.

⚠️ **Risk:** If the server list is somehow empty (e.g. from a network error or API change not caught during initialization) or the cursor gets misaligned, pressing enter would cause a slice bounds out of range panic. This crashes the application abruptly, which can result in a Denial of Service (DoS) for the user.

🛡️ **Solution:** The fix adds a strict bounds check at the beginning of the `case "enter":` handler. It ensures `s.model.Cursor` is within the valid range `[0, len(s.model.ServerList) - 1]`. If it is out of bounds, the application safely halts the server selection process, sets a descriptive error message (`"invalid server selection"`), and returns early without trying to access the array or starting the speed test goroutine.

*(Note: There were no test files to run in this repo, so `go test ./...` was executed and reported `[no test files]`, but the fix was confirmed logically sound and safe.)*

---
*PR created automatically by Jules for task [929782038378751141](https://jules.google.com/task/929782038378751141) started by @jkleinne*