### PR TITLE
🔒 Fix panic risk due to send on closed channel in UploadTest and DownloadTest

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -122,7 +122,9 @@ func (m *Model) PerformSpeedTest(server *speedtest.Server, updateChan chan<- Pro
 
 	sendUpdate(0.5, "Starting download test...", updateChan)
 	done := make(chan struct{})
+	dlDone := make(chan struct{})
 	go func() {
+		defer close(dlDone)
 		start := time.Now()
 		ticker := time.NewTicker(200 * time.Millisecond)
 		defer ticker.Stop()
@@ -148,6 +150,7 @@ func (m *Model) PerformSpeedTest(server *speedtest.Server, updateChan chan<- Pro
 	err = server.DownloadTest()
 	sendUpdate(0.75, fmt.Sprintf("Download test completed. server.DLSpeed: %f bps", server.DLSpeed), updateChan)
 	close(done)
+	<-dlDone
 	if err != nil {
 		return fmt.Errorf("download test failed: %v", err)
 	}
@@ -156,7 +159,9 @@ func (m *Model) PerformSpeedTest(server *speedtest.Server, updateChan chan<- Pro
 
 	sendUpdate(0.8, "Starting upload test...", updateChan)
 	done = make(chan struct{})
+	ulDone := make(chan struct{})
 	go func() {
+		defer close(ulDone)
 		start := time.Now()
 		ticker := time.NewTicker(200 * time.Millisecond)
 		defer ticker.Stop()
@@ -180,6 +185,7 @@ func (m *Model) PerformSpeedTest(server *speedtest.Server, updateChan chan<- Pro
 	}()
 	err = server.UploadTest()
 	close(done)
+	<-ulDone
 	if err != nil {
 		return fmt.Errorf("upload test failed: %v", err)
 	}


### PR DESCRIPTION
🎯 **What:** Fixed a panic vulnerability in `PerformSpeedTest` where a background goroutine could attempt to send a progress update to a closed channel.

⚠️ **Risk:** If an error occurred during `DownloadTest` or `UploadTest`, `PerformSpeedTest` would return the error immediately. The caller would then close `updateChan`. However, the background ticker goroutine was still running and attempting to send progress updates to `updateChan`, leading to a "send on closed channel" panic and crashing the application.

🛡️ **Solution:** Added `dlDone` and `ulDone` synchronization channels to both the `DownloadTest` and `UploadTest` routines. These channels are closed when the respective progress goroutines exit via a `defer`. The main routine now waits (`<-dlDone` / `<-ulDone`) before returning any error from `DownloadTest()` or `UploadTest()`. This ensures the goroutines are fully stopped before the caller gets control back and closes `updateChan`.

---
*PR created automatically by Jules for task [6024334442643616939](https://jules.google.com/task/6024334442643616939) started by @jkleinne*