### PR TITLE
feat: async server list fetching and test cancellation

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -18,6 +19,7 @@ type speedTest struct {
 	err          error
 	progressChan chan model.ProgressUpdate
 	errChan      chan error
+	cancelTest   context.CancelFunc
 }
 
 type progressMsg struct {
@@ -29,8 +31,36 @@ type testComplete struct {
 	err error
 }
 
+type serverListMsg struct {
+	err error
+}
+
+func fetchServerListCmd(m *model.Model) tea.Cmd {
+	return func() tea.Msg {
+		err := m.FetchServerList(context.Background())
+		return serverListMsg{err: err}
+	}
+}
+
 func (s *speedTest) Init() tea.Cmd {
-	return s.spinner.Tick
+	s.model.FetchingServers = true
+	cmds := []tea.Cmd{fetchServerListCmd(s.model)}
+
+	if len(s.model.TestHistory) == 0 {
+		// First launch: show loading spinner since there's nothing else to display
+		s.model.PendingServerSelection = true
+		s.model.CurrentPhase = "Fetching server list..."
+		cmds = append(cmds, s.spinner.Tick)
+	}
+
+	return tea.Batch(cmds...)
+}
+
+func (s *speedTest) cancelTestIfRunning() {
+	if s.cancelTest != nil {
+		s.cancelTest()
+		s.cancelTest = nil
+	}
 }
 
 func (s *speedTest) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -38,7 +68,14 @@ func (s *speedTest) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		if s.model.SelectingServer {
+		if s.model.FetchingServers && s.model.PendingServerSelection {
+			// Spinner is visible while waiting for server list — only allow quit
+			switch msg.String() {
+			case "q", "ctrl+c":
+				s.quitting = true
+				return s, tea.Quit
+			}
+		} else if s.model.SelectingServer {
 			switch msg.String() {
 			case "q", "ctrl+c":
 				s.quitting = true
@@ -64,15 +101,18 @@ func (s *speedTest) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				s.model.CurrentPhase = "Starting speed test..."
 				s.model.Error = nil
 
+				ctx, cancel := context.WithCancel(context.Background())
+				s.cancelTest = cancel
+
 				s.progressChan = make(chan model.ProgressUpdate)
 				s.errChan = make(chan error, 1)
 				go func() {
 					server := s.model.ServerList[s.model.Cursor]
-					err := s.model.PerformSpeedTest(server, s.progressChan)
+					err := s.model.PerformSpeedTest(ctx, server, s.progressChan)
 					s.errChan <- err
 					close(s.progressChan)
 				}()
-				s.model.ShowHelp = false // Hide help when starting speed test
+				s.model.ShowHelp = false
 				return s, tea.Batch(
 					s.spinner.Tick,
 					waitForProgress(s.progressChan, s.errChan),
@@ -81,10 +121,18 @@ func (s *speedTest) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			switch msg.String() {
 			case "q", "ctrl+c":
+				s.cancelTestIfRunning()
 				s.quitting = true
 				return s, tea.Quit
 			case "n":
 				if !s.model.Testing && !s.model.SelectingServer {
+					if s.model.FetchingServers {
+						// Servers still loading — show the spinner and queue the transition
+						s.model.PendingServerSelection = true
+						s.model.CurrentPhase = "Fetching server list..."
+						s.model.ShowHelp = false
+						return s, s.spinner.Tick
+					}
 					s.model.SelectingServer = true
 					s.model.ShowHelp = false
 				}
@@ -102,6 +150,18 @@ func (s *speedTest) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		s.spinner, tickCmd = s.spinner.Update(msg)
 		return s, tickCmd
 
+	case serverListMsg:
+		s.model.FetchingServers = false
+		s.model.CurrentPhase = ""
+		if msg.err != nil {
+			s.model.Error = msg.err
+			s.model.PendingServerSelection = false
+		} else if s.model.PendingServerSelection || len(s.model.TestHistory) == 0 {
+			s.model.SelectingServer = true
+			s.model.PendingServerSelection = false
+		}
+		return s, nil
+
 	case progressMsg:
 		s.model.Progress = msg.Progress
 		s.model.CurrentPhase = msg.Phase
@@ -115,6 +175,7 @@ func (s *speedTest) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return s, nil
 
 	case testComplete:
+		s.cancelTest = nil
 		s.model.Testing = false
 		if msg.err != nil {
 			s.model.Error = msg.err
@@ -133,7 +194,10 @@ func (s *speedTest) View() string {
 	b.WriteString(ui.RenderTitle(s.model.Width))
 	b.WriteString("\n\n")
 
-	if s.model.SelectingServer {
+	if s.model.FetchingServers && s.model.PendingServerSelection {
+		b.WriteString(ui.RenderSpinner(s.spinner, s.model.Width, s.model.CurrentPhase, 0))
+		b.WriteString("\n\n")
+	} else if s.model.SelectingServer {
 		b.WriteString(ui.RenderServerSelection(s.model, s.model.Width))
 	} else if s.model.Testing {
 		b.WriteString(ui.RenderSpinner(s.spinner, s.model.Width, s.model.CurrentPhase, s.model.Progress))
@@ -182,11 +246,6 @@ func main() {
 	m := model.NewModel()
 	if err := m.LoadHistory(); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to load test history: %v\n", err)
-	}
-
-	if err := m.FetchServerList(); err != nil {
-		fmt.Printf("Error fetching server list: %v\n", err)
-		os.Exit(1)
 	}
 
 	s := speedTest{

--- a/model/model.go
+++ b/model/model.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -32,19 +33,21 @@ type SpeedTestResult struct {
 }
 
 type Model struct {
-	Results         *SpeedTestResult
-	TestHistory     []*SpeedTestResult
-	Testing         bool
-	Progress        float64
-	CurrentPhase    string
-	Error           error
-	ShowHelp        bool
-	Width, Height   int
-	PingResults     []float64 // Used for jitter calculation
-	ServerList      speedtest.Servers
-	SelectingServer bool
-	Cursor          int
-	User            *speedtest.User
+	Results                *SpeedTestResult
+	TestHistory            []*SpeedTestResult
+	Testing                bool
+	FetchingServers        bool
+	Progress               float64
+	CurrentPhase           string
+	Error                  error
+	ShowHelp               bool
+	Width, Height          int
+	PingResults            []float64 // Used for jitter calculation
+	ServerList             speedtest.Servers
+	SelectingServer        bool
+	PendingServerSelection bool
+	Cursor                 int
+	User                   *speedtest.User
 }
 
 func NewModel() *Model {
@@ -126,21 +129,22 @@ func (m *Model) SaveHistory() error {
 	return nil
 }
 
-func (m *Model) FetchServerList() error {
-	m.CurrentPhase = "Fetching server list..."
+func (m *Model) FetchServerList(ctx context.Context) error {
 	serverList, err := speedtest.FetchServers()
 	if err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		return fmt.Errorf("failed to fetch servers: %v", err)
 	}
 	sort.Slice(serverList, func(i, j int) bool {
 		return serverList[i].Latency < serverList[j].Latency
 	})
 	m.ServerList = serverList
-	m.CurrentPhase = ""
 	return nil
 }
 
-func (m *Model) PerformSpeedTest(server *speedtest.Server, updateChan chan<- ProgressUpdate) error {
+func (m *Model) PerformSpeedTest(ctx context.Context, server *speedtest.Server, updateChan chan<- ProgressUpdate) error {
 	var err error
 	m.Testing = true
 	m.Progress = 0
@@ -156,11 +160,20 @@ func (m *Model) PerformSpeedTest(server *speedtest.Server, updateChan chan<- Pro
 		m.User = user
 	}
 
+	if ctx.Err() != nil {
+		m.Testing = false
+		return ctx.Err()
+	}
+
 	sendUpdate(0.2, fmt.Sprintf("Testing with server: %s", server.Name), updateChan)
 
 	sendUpdate(0.3, "Measuring ping and jitter...", updateChan)
 	var sumPing float64
 	for i := 0; i < 10; i++ {
+		if ctx.Err() != nil {
+			m.Testing = false
+			return ctx.Err()
+		}
 		err := server.PingTest(func(latency time.Duration) {
 			ping := float64(latency.Milliseconds())
 			m.PingResults = append(m.PingResults, ping)
@@ -180,7 +193,12 @@ func (m *Model) PerformSpeedTest(server *speedtest.Server, updateChan chan<- Pro
 		if err != nil {
 			continue
 		}
-		time.Sleep(100 * time.Millisecond) // Small delay between pings
+		select {
+		case <-ctx.Done():
+			m.Testing = false
+			return ctx.Err()
+		case <-time.After(100 * time.Millisecond): // Small delay between pings
+		}
 	}
 
 	var jitter float64
@@ -190,6 +208,11 @@ func (m *Model) PerformSpeedTest(server *speedtest.Server, updateChan chan<- Pro
 			sum += math.Abs(m.PingResults[i] - m.PingResults[i-1])
 		}
 		jitter = sum / float64(len(m.PingResults)-1)
+	}
+
+	if ctx.Err() != nil {
+		m.Testing = false
+		return ctx.Err()
 	}
 
 	sendUpdate(0.5, "Starting download test...", updateChan)
@@ -203,6 +226,8 @@ func (m *Model) PerformSpeedTest(server *speedtest.Server, updateChan chan<- Pro
 		for {
 			select {
 			case <-done:
+				return
+			case <-ctx.Done():
 				return
 			case <-ticker.C:
 				elapsed := time.Since(start)
@@ -220,14 +245,18 @@ func (m *Model) PerformSpeedTest(server *speedtest.Server, updateChan chan<- Pro
 		}
 	}()
 	err = server.DownloadTest()
-	sendUpdate(0.75, fmt.Sprintf("Download test completed. server.DLSpeed: %f bps", server.DLSpeed), updateChan)
 	close(done)
 	<-doneAck
+	if ctx.Err() != nil {
+		m.Testing = false
+		return ctx.Err()
+	}
 	if err != nil {
+		m.Testing = false
 		return fmt.Errorf("download test failed: %v", err)
 	}
 	dlSpeed := float64(server.DLSpeed) / 1000000
-	sendUpdate(0.7, fmt.Sprintf("Download complete: %.2f MBps (server.DLSpeed: %f)", dlSpeed, server.DLSpeed), updateChan)
+	sendUpdate(0.75, fmt.Sprintf("Download complete: %.2f MBps", dlSpeed), updateChan)
 
 	sendUpdate(0.8, "Starting upload test...", updateChan)
 	done = make(chan struct{})
@@ -240,6 +269,8 @@ func (m *Model) PerformSpeedTest(server *speedtest.Server, updateChan chan<- Pro
 		for {
 			select {
 			case <-done:
+				return
+			case <-ctx.Done():
 				return
 			case <-ticker.C:
 				elapsed := time.Since(start)
@@ -258,7 +289,12 @@ func (m *Model) PerformSpeedTest(server *speedtest.Server, updateChan chan<- Pro
 	err = server.UploadTest()
 	close(done)
 	<-doneAck
+	if ctx.Err() != nil {
+		m.Testing = false
+		return ctx.Err()
+	}
 	if err != nil {
+		m.Testing = false
 		return fmt.Errorf("upload test failed: %v", err)
 	}
 	ulSpeed := float64(server.ULSpeed) / 1000000


### PR DESCRIPTION
- Move server list fetching to an asynchronous background task on startup.
- Show a loading spinner during server fetch on first launch or if the user requests a new test before the fetch completes.
- Allow users to quit the application gracefully during an active speed test by propagating context cancellation to the ping, download, and upload phases.