### PR TITLE
feat: testing infrastructure and unit tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -248,7 +248,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	m := model.NewModel()
+	m := model.NewDefaultModel()
 	if err := m.LoadHistory(); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to load test history: %v\n", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jkleinne/lazyspeed/model"
+	"github.com/jkleinne/lazyspeed/ui"
+	"github.com/showwin/speedtest-go/speedtest"
+)
+
+func TestGetVersionInfo(t *testing.T) {
+	// Reset package vars after test
+	origVersion, origCommit, origDate := version, commit, date
+	defer func() {
+		version, commit, date = origVersion, origCommit, origDate
+	}()
+
+	// Case 1: All set
+	version = "1.0.0"
+	commit = "abcdef"
+	date = "2023-01-01"
+	res := GetVersionInfo()
+	if !strings.Contains(res, "1.0.0") || !strings.Contains(res, "2023-01-01") {
+		t.Errorf("Expected full version info, got %q", res)
+	}
+
+	// Case 2: Only version set
+	version = "2.0.0"
+	commit = ""
+	date = ""
+	res = GetVersionInfo()
+	if !strings.Contains(res, "2.0.0") || strings.Contains(res, "built:") {
+		t.Errorf("Expected simple version info, got %q", res)
+	}
+}
+
+func TestUpdateServerListMsg(t *testing.T) {
+	m := model.NewDefaultModel()
+	s := speedTest{
+		model:   m,
+		spinner: ui.DefaultSpinner,
+	}
+
+	// Simulate successful server fetch
+	s.model.FetchingServers = true
+	s.model.PendingServerSelection = true
+
+	newModel, cmd := s.Update(serverListMsg{err: nil})
+	newS := newModel.(*speedTest)
+
+	if newS.model.FetchingServers {
+		t.Errorf("Expected FetchingServers to be false")
+	}
+	if !newS.model.SelectingServer {
+		t.Errorf("Expected SelectingServer to be true")
+	}
+	if cmd != nil {
+		t.Errorf("Expected nil command")
+	}
+
+	// Simulate failed server fetch
+	s.model.FetchingServers = true
+	s.model.PendingServerSelection = true
+	s.model.SelectingServer = false
+	newModel, _ = s.Update(serverListMsg{err: errors.New("fetch failed")})
+	newS = newModel.(*speedTest)
+
+	if newS.model.FetchingServers {
+		t.Errorf("Expected FetchingServers to be false")
+	}
+	if newS.model.SelectingServer {
+		t.Errorf("Expected SelectingServer to remain false")
+	}
+	if newS.model.Error == nil || newS.model.Error.Error() != "fetch failed" {
+		t.Errorf("Expected error to be set")
+	}
+}
+
+func TestUpdateKeyMsgQuit(t *testing.T) {
+	m := model.NewDefaultModel()
+	s := speedTest{model: m}
+
+	// "q" to quit
+	newModel, cmd := s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	newS := newModel.(*speedTest)
+
+	if !newS.quitting {
+		t.Errorf("Expected quitting to be true")
+	}
+	if cmd == nil {
+		t.Errorf("Expected quit command")
+	}
+}
+
+func TestUpdateKeyMsgNavigation(t *testing.T) {
+	m := model.NewDefaultModel()
+	m.ServerList = speedtest.Servers{
+		&speedtest.Server{Name: "Server 1"},
+		&speedtest.Server{Name: "Server 2"},
+		&speedtest.Server{Name: "Server 3"},
+	}
+	m.SelectingServer = true
+	s := speedTest{model: m}
+
+	// Initial cursor is 0. Move down.
+	newModel, _ := s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	newS := newModel.(*speedTest)
+	if newS.model.Cursor != 1 {
+		t.Errorf("Expected cursor to move to 1, got %d", newS.model.Cursor)
+	}
+
+	// Move up
+	newModel, _ = newS.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	newS = newModel.(*speedTest)
+	if newS.model.Cursor != 0 {
+		t.Errorf("Expected cursor to move back to 0, got %d", newS.model.Cursor)
+	}
+
+	// Move up at top boundary
+	newModel, _ = newS.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	newS = newModel.(*speedTest)
+	if newS.model.Cursor != 0 {
+		t.Errorf("Expected cursor to stay at 0, got %d", newS.model.Cursor)
+	}
+}
+
+func TestView(t *testing.T) {
+	m := model.NewDefaultModel()
+	s := speedTest{
+		model:   m,
+		spinner: ui.DefaultSpinner,
+	}
+
+	// Fetching
+	s.model.FetchingServers = true
+	s.model.PendingServerSelection = true
+	s.model.CurrentPhase = "Fetching..."
+	view := s.View()
+	if !strings.Contains(view, "Fetching...") {
+		t.Errorf("Expected fetching view")
+	}
+
+	// Selecting
+	s.model.FetchingServers = false
+	s.model.PendingServerSelection = false
+	s.model.SelectingServer = true
+	s.model.ServerList = speedtest.Servers{
+		&speedtest.Server{Name: "Server 1", Latency: 10 * time.Millisecond},
+	}
+	view = s.View()
+	if !strings.Contains(view, "Select a server:") {
+		t.Errorf("Expected server selection view")
+	}
+
+	// Testing
+	s.model.SelectingServer = false
+	s.model.Testing = true
+	s.model.CurrentPhase = "Ping test..."
+	view = s.View()
+	if !strings.Contains(view, "Ping test...") {
+		t.Errorf("Expected testing view")
+	}
+}

--- a/model/backend.go
+++ b/model/backend.go
@@ -1,0 +1,40 @@
+package model
+
+import (
+	"time"
+
+	"github.com/showwin/speedtest-go/speedtest"
+)
+
+// Backend interface wraps the network I/O operations from speedtest-go
+// to allow mocking in unit tests.
+type Backend interface {
+	FetchUserInfo() (*speedtest.User, error)
+	FetchServers() (speedtest.Servers, error)
+	PingTest(server *speedtest.Server, fn func(time.Duration)) error
+	DownloadTest(server *speedtest.Server) error
+	UploadTest(server *speedtest.Server) error
+}
+
+// realBackend is the default implementation that calls the actual speedtest-go library.
+type realBackend struct{}
+
+func (b *realBackend) FetchUserInfo() (*speedtest.User, error) {
+	return speedtest.FetchUserInfo()
+}
+
+func (b *realBackend) FetchServers() (speedtest.Servers, error) {
+	return speedtest.FetchServers()
+}
+
+func (b *realBackend) PingTest(server *speedtest.Server, fn func(time.Duration)) error {
+	return server.PingTest(fn)
+}
+
+func (b *realBackend) DownloadTest(server *speedtest.Server) error {
+	return server.DownloadTest()
+}
+
+func (b *realBackend) UploadTest(server *speedtest.Server) error {
+	return server.UploadTest()
+}

--- a/model/model.go
+++ b/model/model.go
@@ -53,13 +53,14 @@ type Model struct {
 	Width, Height          int
 	PingResults            []float64 // Used for jitter calculation
 	ServerList             speedtest.Servers
+	Backend                Backend
 	SelectingServer        bool
 	PendingServerSelection bool
 	Cursor                 int
 	User                   *speedtest.User
 }
 
-func NewModel() *Model {
+func NewModel(backend Backend) *Model {
 	return &Model{
 		Results:         nil,
 		TestHistory:     make([]*SpeedTestResult, 0),
@@ -69,7 +70,12 @@ func NewModel() *Model {
 		ShowHelp:        true,
 		SelectingServer: false,
 		Cursor:          0,
+		Backend:         backend,
 	}
+}
+
+func NewDefaultModel() *Model {
+	return NewModel(&realBackend{})
 }
 
 func sendUpdate(progress float64, phase string, updateChan chan<- ProgressUpdate) {
@@ -139,7 +145,7 @@ func (m *Model) SaveHistory() error {
 }
 
 func (m *Model) FetchServerList(ctx context.Context) error {
-	serverList, err := speedtest.FetchServers()
+	serverList, err := m.Backend.FetchServers()
 	if err != nil {
 		if ctx.Err() != nil {
 			return ctx.Err()
@@ -165,7 +171,7 @@ func (m *Model) PerformSpeedTest(ctx context.Context, server *speedtest.Server, 
 	sendUpdate(0.0, "Initializing speed test...", updateChan)
 
 	sendUpdate(0.1, "Fetching network information...", updateChan)
-	user, userErr := speedtest.FetchUserInfo()
+	user, userErr := m.Backend.FetchUserInfo()
 	if userErr == nil {
 		m.User = user
 	} else {
@@ -186,7 +192,7 @@ func (m *Model) PerformSpeedTest(ctx context.Context, server *speedtest.Server, 
 			m.Testing = false
 			return ctx.Err()
 		}
-		err := server.PingTest(func(latency time.Duration) {
+		err := m.Backend.PingTest(server, func(latency time.Duration) {
 			ping := float64(latency.Milliseconds())
 			m.PingResults = append(m.PingResults, ping)
 			sumPing += ping
@@ -256,7 +262,7 @@ func (m *Model) PerformSpeedTest(ctx context.Context, server *speedtest.Server, 
 			}
 		}
 	}()
-	err = server.DownloadTest()
+	err = m.Backend.DownloadTest(server)
 	close(done)
 	<-doneAck
 	if ctx.Err() != nil {
@@ -298,7 +304,7 @@ func (m *Model) PerformSpeedTest(ctx context.Context, server *speedtest.Server, 
 			}
 		}
 	}()
-	err = server.UploadTest()
+	err = m.Backend.UploadTest(server)
 	close(done)
 	<-doneAck
 	if ctx.Err() != nil {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -1,11 +1,62 @@
 package model
 
 import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/showwin/speedtest-go/speedtest"
 )
 
+// mockBackend implements Backend for testing
+type mockBackend struct {
+	fetchUserInfoFn func() (*speedtest.User, error)
+	fetchServersFn  func() (speedtest.Servers, error)
+	pingTestFn      func(server *speedtest.Server, fn func(time.Duration)) error
+	downloadTestFn  func(server *speedtest.Server) error
+	uploadTestFn    func(server *speedtest.Server) error
+}
+
+func (m *mockBackend) FetchUserInfo() (*speedtest.User, error) {
+	if m.fetchUserInfoFn != nil {
+		return m.fetchUserInfoFn()
+	}
+	return &speedtest.User{IP: "127.0.0.1", Isp: "Test ISP"}, nil
+}
+
+func (m *mockBackend) FetchServers() (speedtest.Servers, error) {
+	if m.fetchServersFn != nil {
+		return m.fetchServersFn()
+	}
+	return speedtest.Servers{}, nil
+}
+
+func (m *mockBackend) PingTest(server *speedtest.Server, fn func(time.Duration)) error {
+	if m.pingTestFn != nil {
+		return m.pingTestFn(server, fn)
+	}
+	return nil
+}
+
+func (m *mockBackend) DownloadTest(server *speedtest.Server) error {
+	if m.downloadTestFn != nil {
+		return m.downloadTestFn(server)
+	}
+	return nil
+}
+
+func (m *mockBackend) UploadTest(server *speedtest.Server) error {
+	if m.uploadTestFn != nil {
+		return m.uploadTestFn(server)
+	}
+	return nil
+}
+
 func TestNewModel(t *testing.T) {
-	m := NewModel()
+	m := NewModel(&mockBackend{})
 
 	if m.Results != nil {
 		t.Errorf("Expected Results to be nil, got %v", m.Results)
@@ -39,5 +90,197 @@ func TestNewModel(t *testing.T) {
 
 	if m.Cursor != 0 {
 		t.Errorf("Expected Cursor to be 0, got %d", m.Cursor)
+	}
+}
+
+func TestHistoryLoadSave(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	m := NewModel(&mockBackend{})
+
+	// Case 1: missing file (no error)
+	err := m.LoadHistory()
+	if err != nil {
+		t.Fatalf("LoadHistory on missing file failed: %v", err)
+	}
+	if len(m.TestHistory) != 0 {
+		t.Errorf("Expected empty history, got %d", len(m.TestHistory))
+	}
+
+	// Case 2: Save empty history
+	err = m.SaveHistory()
+	if err != nil {
+		t.Fatalf("SaveHistory failed: %v", err)
+	}
+
+	// Case 3: Save and Load with data
+	m.TestHistory = []*SpeedTestResult{
+		{DownloadSpeed: 100},
+		{DownloadSpeed: 200},
+	}
+	err = m.SaveHistory()
+	if err != nil {
+		t.Fatalf("SaveHistory with data failed: %v", err)
+	}
+
+	m2 := NewModel(&mockBackend{})
+	err = m2.LoadHistory()
+	if err != nil {
+		t.Fatalf("LoadHistory with data failed: %v", err)
+	}
+	if len(m2.TestHistory) != 2 {
+		t.Errorf("Expected 2 history items, got %d", len(m2.TestHistory))
+	}
+	if m2.Results == nil || m2.Results.DownloadSpeed != 200 {
+		t.Errorf("Expected Results to be last item (200), got %v", m2.Results)
+	}
+
+	// Case 4: Save > max size
+	for i := 0; i < 60; i++ {
+		m2.TestHistory = append(m2.TestHistory, &SpeedTestResult{DownloadSpeed: float64(i)})
+	}
+	err = m2.SaveHistory()
+	if err != nil {
+		t.Fatalf("SaveHistory > max size failed: %v", err)
+	}
+
+	m3 := NewModel(&mockBackend{})
+	err = m3.LoadHistory()
+	if err != nil {
+		t.Fatalf("LoadHistory > max size failed: %v", err)
+	}
+	if len(m3.TestHistory) != 50 {
+		t.Errorf("Expected exactly 50 history items, got %d", len(m3.TestHistory))
+	}
+
+	// Case 5: Corrupt JSON
+	historyPath := filepath.Join(tmpDir, ".lazyspeed_history.json")
+	os.WriteFile(historyPath, []byte("invalid json"), 0644)
+	err = m3.LoadHistory()
+	if err == nil {
+		t.Errorf("Expected error loading corrupt JSON, got nil")
+	}
+}
+
+func TestFetchServerList(t *testing.T) {
+	// Case 1: Normal fetch (mocked) and sort
+	m := NewModel(&mockBackend{
+		fetchServersFn: func() (speedtest.Servers, error) {
+			return speedtest.Servers{
+				&speedtest.Server{Name: "Server C", Latency: 30 * time.Millisecond},
+				&speedtest.Server{Name: "Server A", Latency: 10 * time.Millisecond},
+				&speedtest.Server{Name: "Server B", Latency: 20 * time.Millisecond},
+			}, nil
+		},
+	})
+
+	err := m.FetchServerList(context.Background())
+	if err != nil {
+		t.Fatalf("FetchServerList failed: %v", err)
+	}
+	if len(m.ServerList) != 3 {
+		t.Fatalf("Expected 3 servers, got %d", len(m.ServerList))
+	}
+	// Verify sorted by latency
+	if m.ServerList[0].Name != "Server A" || m.ServerList[1].Name != "Server B" || m.ServerList[2].Name != "Server C" {
+		t.Errorf("ServerList not sorted correctly by latency")
+	}
+
+	// Case 2: Error from backend
+	m = NewModel(&mockBackend{
+		fetchServersFn: func() (speedtest.Servers, error) {
+			return nil, errors.New("backend error")
+		},
+	})
+	err = m.FetchServerList(context.Background())
+	if err == nil || err.Error() != "failed to fetch servers: backend error" {
+		t.Errorf("Expected backend error, got %v", err)
+	}
+
+	// Case 3: Cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = m.FetchServerList(ctx)
+	if err != context.Canceled {
+		t.Errorf("Expected context.Canceled, got %v", err)
+	}
+}
+
+func TestPerformSpeedTest(t *testing.T) {
+	// To avoid saving history to user dir in test, override HOME
+	t.Setenv("HOME", t.TempDir())
+
+	m := NewModel(&mockBackend{
+		pingTestFn: func(server *speedtest.Server, fn func(time.Duration)) error {
+			// Simulate a few successful pings
+			fn(10 * time.Millisecond)
+			fn(12 * time.Millisecond)
+			return nil
+		},
+		downloadTestFn: func(server *speedtest.Server) error {
+			server.DLSpeed = 100 * bytesToMB // 100 MBps
+			return nil
+		},
+		uploadTestFn: func(server *speedtest.Server) error {
+			server.ULSpeed = 50 * bytesToMB // 50 MBps
+			return nil
+		},
+	})
+
+	ctx := context.Background()
+	updateChan := make(chan ProgressUpdate, 100) // Buffer so it doesn't block
+
+	server := &speedtest.Server{
+		Name:    "Test Server",
+		Sponsor: "Test Sponsor",
+		Country: "Test Country",
+	}
+
+	err := m.PerformSpeedTest(ctx, server, updateChan)
+	if err != nil {
+		t.Fatalf("PerformSpeedTest failed: %v", err)
+	}
+
+	if m.Results == nil {
+		t.Fatalf("Expected Results to be populated")
+	}
+	if m.Results.DownloadSpeed != 100.0 {
+		t.Errorf("Expected DL speed 100.0, got %f", m.Results.DownloadSpeed)
+	}
+	if m.Results.UploadSpeed != 50.0 {
+		t.Errorf("Expected UL speed 50.0, got %f", m.Results.UploadSpeed)
+	}
+	if m.Testing != false {
+		t.Errorf("Expected Testing to be false at end")
+	}
+}
+
+func TestPerformSpeedTestFailures(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	ctx := context.Background()
+	server := &speedtest.Server{}
+
+	// Case: All pings fail
+	m := NewModel(&mockBackend{
+		pingTestFn: func(server *speedtest.Server, fn func(time.Duration)) error {
+			return errors.New("ping failed")
+		},
+	})
+	updateChan := make(chan ProgressUpdate, 100)
+	_ = m.PerformSpeedTest(ctx, server, updateChan)
+	if m.Results != nil && m.Results.Ping != 0.0 {
+		t.Errorf("Expected avg ping to be 0.0 when all fail, got %f", m.Results.Ping)
+	}
+
+	// Case: Download fails
+	m = NewModel(&mockBackend{
+		downloadTestFn: func(server *speedtest.Server) error {
+			return errors.New("dl failed")
+		},
+	})
+	err := m.PerformSpeedTest(ctx, server, updateChan)
+	if err == nil || err.Error() != "download test failed: dl failed" {
+		t.Errorf("Expected download error, got %v", err)
 	}
 }

--- a/ui/ui_test.go
+++ b/ui/ui_test.go
@@ -1,11 +1,21 @@
 package ui
 
 import (
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/jkleinne/lazyspeed/model"
+	"github.com/showwin/speedtest-go/speedtest"
 )
+
+func TestMain(m *testing.M) {
+	// Ensure deterministic rendering for tests regardless of terminal
+	lipgloss.SetHasDarkBackground(true)
+	m.Run()
+}
 
 func TestRenderTitle(t *testing.T) {
 	tests := []struct {
@@ -59,5 +69,131 @@ func TestRenderTitle(t *testing.T) {
 				t.Errorf("RenderTitle() width = %d, want %d", actualWidth, expectedWidth)
 			}
 		})
+	}
+}
+
+func TestRenderSpinner(t *testing.T) {
+	res := RenderSpinner(DefaultSpinner, 100, "Testing phase", 0.5)
+	if !strings.Contains(res, "Testing phase") {
+		t.Errorf("Expected phase text to be present")
+	}
+
+	// Negative progress
+	res = RenderSpinner(DefaultSpinner, 100, "Testing phase", -0.1)
+	if !strings.Contains(res, "Testing phase") {
+		t.Errorf("Should handle negative progress gracefully")
+	}
+}
+
+func TestRenderResults(t *testing.T) {
+	m := model.NewDefaultModel()
+
+	// Case 1: Empty history
+	res := RenderResults(m, 100)
+	if res != "" {
+		t.Errorf("Expected empty string for empty history, got %q", res)
+	}
+
+	// Case 2: One entry
+	m.TestHistory = []*model.SpeedTestResult{
+		{
+			DownloadSpeed: 100.0,
+			UploadSpeed:   50.0,
+			Ping:          10.5,
+			Jitter:        2.1,
+			ServerName:    "Test Server",
+			ServerLoc:     "Test City",
+			Timestamp:     time.Now(),
+		},
+	}
+	res = RenderResults(m, 100)
+	if !strings.Contains(res, "Latest Test Results:") {
+		t.Errorf("Expected Latest Test Results block")
+	}
+	if strings.Contains(res, "Previous Tests") {
+		t.Errorf("Did not expect Previous Tests table for 1 result")
+	}
+
+	// Case 3: Two entries (adds table)
+	m.TestHistory = append(m.TestHistory, &model.SpeedTestResult{
+		DownloadSpeed: 200.0,
+		UploadSpeed:   100.0,
+		Ping:          5.0,
+		ServerName:    "New Server",
+		ServerSponsor: "Great Sponsor",
+		Distance:      42.5,
+		UserIP:        "1.1.1.1",
+		UserISP:       "Cloudflare",
+		Timestamp:     time.Now(),
+	})
+	res = RenderResults(m, 100)
+	if !strings.Contains(res, "Latest Test Results:") {
+		t.Errorf("Expected Latest Test Results block")
+	}
+	if !strings.Contains(res, "Previous Tests") {
+		t.Errorf("Expected Previous Tests table for 2+ results")
+	}
+	if !strings.Contains(res, "Great Sponsor") {
+		t.Errorf("Expected sponsor to be printed")
+	}
+	if !strings.Contains(res, "42.5 km") {
+		t.Errorf("Expected distance to be printed")
+	}
+	if !strings.Contains(res, "1.1.1.1 (Cloudflare)") {
+		t.Errorf("Expected IP and ISP to be printed")
+	}
+}
+
+func TestRenderError(t *testing.T) {
+	if RenderError(nil, 100) != "" {
+		t.Errorf("Expected empty string for nil error")
+	}
+
+	res := RenderError(errors.New("test error"), 100)
+	if !strings.Contains(res, "Error: test error") {
+		t.Errorf("Expected error message to be present")
+	}
+}
+
+func TestRenderWarning(t *testing.T) {
+	if RenderWarning("", 100) != "" {
+		t.Errorf("Expected empty string for empty warning")
+	}
+
+	res := RenderWarning("test warning", 100)
+	if !strings.Contains(res, "Warning: test warning") {
+		t.Errorf("Expected warning message to be present")
+	}
+}
+
+func TestRenderHelp(t *testing.T) {
+	res := RenderHelp(100)
+	if !strings.Contains(res, "Controls:") || !strings.Contains(res, "n: New Test") {
+		t.Errorf("Expected help controls to be present")
+	}
+}
+
+func TestRenderServerSelection(t *testing.T) {
+	m := model.NewDefaultModel()
+
+	// Case 1: Empty list
+	res := RenderServerSelection(m, 100)
+	if !strings.Contains(res, "Select a server:") {
+		t.Errorf("Expected selection header")
+	}
+
+	// Case 2: Populated list
+	m.ServerList = speedtest.Servers{
+		&speedtest.Server{Name: "Server 1", Sponsor: "Sponsor 1", Country: "Country 1", Latency: 10 * time.Millisecond},
+		&speedtest.Server{Name: "Server 2", Sponsor: "Sponsor 2", Country: "Country 2", Latency: 20 * time.Millisecond},
+	}
+	m.Cursor = 1
+
+	res = RenderServerSelection(m, 100)
+	if !strings.Contains(res, "> Sponsor 2") {
+		t.Errorf("Expected cursor on Server 2")
+	}
+	if !strings.Contains(res, "  Sponsor 1") {
+		t.Errorf("Expected no cursor on Server 1")
 	}
 }


### PR DESCRIPTION
- Define Backend interface wrapping speedtest-go operations to enable mocking
- Refactor model to use injected Backend
- Add unit tests for model, ui, and main packages