### PR TITLE
fix: fix --count --json emitting invalid JSON and related edge cases

### DIFF
--- a/cmd_run.go
+++ b/cmd_run.go
@@ -24,13 +24,19 @@ var (
 var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run a speed test non-interactively",
+	PreRunE: func(_ *cobra.Command, _ []string) error {
+		if runCount < 1 {
+			return fmt.Errorf("--count must be at least 1, got %d", runCount)
+		}
+		return nil
+	},
 	Run: func(_ *cobra.Command, _ []string) {
 		runHeadlessTest()
 	},
 }
 
 func init() {
-	runCmd.Flags().BoolVar(&runJSON, "json", false, "Output results as JSON to stdout")
+	runCmd.Flags().BoolVar(&runJSON, "json", false, "Output as JSON; single run emits a bare object, --count N>1 emits a JSON array")
 	runCmd.Flags().BoolVar(&runCSV, "csv", false, "Output results as CSV to stdout")
 	runCmd.Flags().BoolVar(&runSimple, "simple", false, "Minimal output (one line: DL/UL/Ping)")
 	runCmd.Flags().StringVar(&runServerID, "server", "", "Skip server selection, use a specific server ID")
@@ -93,6 +99,10 @@ func runHeadlessTest() {
 		_ = csvWriter.Write([]string{"timestamp", "server", "country", "download_mbps", "upload_mbps", "ping_ms", "jitter_ms", "ip", "isp"})
 	}
 
+	// Collect results for JSON mode so we can emit valid JSON after all runs.
+	// (Printing one object per iteration produces invalid JSON when --count > 1.)
+	var jsonResults []*model.SpeedTestResult
+
 	for i := 0; i < runCount; i++ {
 		if runCount > 1 && !runJSON && !runCSV {
 			fmt.Printf("\n--- Test %d of %d ---\n", i+1, runCount)
@@ -113,8 +123,7 @@ func runHeadlessTest() {
 		_ = m.SaveHistory() // ignore headless save errors
 
 		if runJSON {
-			data, _ := json.MarshalIndent(res, "", "  ")
-			fmt.Println(string(data))
+			jsonResults = append(jsonResults, res)
 		} else if runCSV {
 			_ = csvWriter.Write([]string{
 				res.Timestamp.Format("2006-01-02T15:04:05Z07:00"),
@@ -136,5 +145,33 @@ func runHeadlessTest() {
 			fmt.Printf("🔄 Ping: %.2f ms\n", res.Ping)
 			fmt.Printf("📊 Jitter: %.2f ms\n", res.Jitter)
 		}
+	}
+
+	// Emit JSON output after all runs so the result is always valid JSON.
+	// --count 1 → bare object (backward-compatible with existing scripts).
+	// --count N → JSON array.
+	if runJSON {
+		data, err := marshalJSONResults(jsonResults)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error serialising results: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(data))
+	}
+}
+
+// marshalJSONResults serialises speed test results for --json output.
+// A single result is marshalled as a bare JSON object to preserve
+// backward-compatibility with existing scripts.
+// Multiple results are marshalled as a JSON array so the output is
+// always valid JSON regardless of --count.
+func marshalJSONResults(results []*model.SpeedTestResult) ([]byte, error) {
+	switch len(results) {
+	case 0:
+		return []byte("[]"), nil
+	case 1:
+		return json.MarshalIndent(results[0], "", "  ")
+	default:
+		return json.MarshalIndent(results, "", "  ")
 	}
 }

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
+
+	"github.com/jkleinne/lazyspeed/model"
 )
 
 func TestVersionCommand(t *testing.T) {
@@ -38,5 +42,75 @@ func TestCommandsConfigured(t *testing.T) {
 	}
 	if !foundHistory {
 		t.Error("history command not registered")
+	}
+}
+
+func TestMarshalJSONResultsEmpty(t *testing.T) {
+	data, err := marshalJSONResults([]*model.SpeedTestResult{})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Must be a valid empty JSON array, not null
+	var arr []map[string]any
+	if err := json.Unmarshal(data, &arr); err != nil {
+		t.Fatalf("Expected valid JSON array, got parse error: %v\noutput: %s", err, data)
+	}
+	if len(arr) != 0 {
+		t.Errorf("Expected empty array, got length %d", len(arr))
+	}
+}
+
+func TestMarshalJSONResultsSingle(t *testing.T) {
+	res := &model.SpeedTestResult{
+		DownloadSpeed: 95.12,
+		UploadSpeed:   45.23,
+		Ping:          12.40,
+		Jitter:        1.50,
+		ServerName:    "Test Server",
+		Timestamp:     time.Date(2026, 3, 15, 9, 0, 0, 0, time.UTC),
+	}
+
+	data, err := marshalJSONResults([]*model.SpeedTestResult{res})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Must be a valid JSON object, not an array
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("Expected bare JSON object, got parse error: %v\noutput: %s", err, data)
+	}
+
+	if _, ok := obj["download_speed"]; !ok {
+		t.Errorf("Expected download_speed key in JSON object")
+	}
+}
+
+func TestMarshalJSONResultsMultiple(t *testing.T) {
+	results := []*model.SpeedTestResult{
+		{DownloadSpeed: 95.12, Ping: 12.40, Timestamp: time.Now()},
+		{DownloadSpeed: 97.44, Ping: 11.90, Timestamp: time.Now()},
+	}
+
+	data, err := marshalJSONResults(results)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Must be a valid JSON array of length 2
+	var arr []map[string]any
+	if err := json.Unmarshal(data, &arr); err != nil {
+		t.Fatalf("Expected JSON array, got parse error: %v\noutput: %s", err, data)
+	}
+
+	if len(arr) != 2 {
+		t.Errorf("Expected array length 2, got %d", len(arr))
+	}
+
+	for i, item := range arr {
+		if _, ok := item["download_speed"]; !ok {
+			t.Errorf("Expected download_speed key in array item %d", i)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a bug where `lazyspeed run --json --count N` emitted N bare JSON
objects to stdout (one per iteration), producing invalid JSON that broke
`jq` and any downstream parser.

## Changes

### `cmd_run.go`
- **Collect, then emit**: JSON results are now accumulated into a slice
  during the loop and marshalled once after all runs complete.
  - `--count 1` → bare object (backward-compatible with existing scripts)
  - `--count N>1` → JSON array (valid JSON, `jq .` works correctly)
- **`--count` validation**: Added `PreRunE` hook that rejects `--count < 1`
  with a clear error before any network call is made.
- **Marshal error handling**: The error return from `marshalJSONResults` is
  now checked; failures print to stderr and exit non-zero instead of
  silently writing a blank line.
- **Empty-slice safety**: `marshalJSONResults` now has an explicit `case 0`
  branch returning `[]byte("[]")` instead of the JSON literal `null`.
- **Flag description**: `--json` help text now documents the output shape
  difference between single and multi-run.

### `cmd_test.go`
- `TestMarshalJSONResultsEmpty` — asserts empty input produces `[]`, not `null`
- `TestMarshalJSONResultsSingle` — asserts single result is a bare object
- `TestMarshalJSONResultsMultiple` — asserts multiple results form a valid array

## Testing

```
make build && make test  # all packages pass
```

## Before / After

```bash
# Before (invalid JSON):
$ lazyspeed run --json --count 2
{ "download_speed": 95.12, ... }
{ "download_speed": 97.44, ... }   # ← second object breaks jq

# After (valid JSON array):
$ lazyspeed run --json --count 2
[
  { "download_speed": 95.12, ... },
  { "download_speed": 97.44, ... }
]

# --count 0 now rejected cleanly:
$ lazyspeed run --json --count 0
Error: --count must be at least 1, got 0
```