### PR TITLE
feat(cli): add lazyspeed servers command

### DIFF
--- a/cmd_servers.go
+++ b/cmd_servers.go
@@ -1,6 +1,118 @@
 package main
 
-// TODO: Implement `lazyspeed servers` command.
-// Should list available speed test servers with columns: ID, Name, Sponsor,
-// Country, and Latency. Useful for discovering server IDs to pass to
-// `lazyspeed run --server <id>`.
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/jkleinne/lazyspeed/model"
+	"github.com/spf13/cobra"
+)
+
+const (
+	serversFormatJSON = "json"
+	serversFormatCSV  = "csv"
+)
+
+var serversFormat string
+
+// serverEntry is a clean serialization struct for JSON/CSV output,
+// decoupled from speedtest-go internals.
+type serverEntry struct {
+	ID       string  `json:"id"`
+	Name     string  `json:"name"`
+	Sponsor  string  `json:"sponsor"`
+	Country  string  `json:"country"`
+	Latency  float64 `json:"latency_ms"`
+	Distance float64 `json:"distance_km"`
+}
+
+var serversCmd = &cobra.Command{
+	Use:   "servers",
+	Short: "List available speed test servers",
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if serversFormat != "" && serversFormat != serversFormatJSON && serversFormat != serversFormatCSV {
+			return fmt.Errorf("invalid --format %q: must be %q or %q", serversFormat, serversFormatJSON, serversFormatCSV)
+		}
+		runServers()
+		return nil
+	},
+}
+
+func runServers() {
+	m := model.NewDefaultModel()
+
+	fmt.Println("Fetching server list...")
+
+	if err := m.FetchServerList(context.Background()); err != nil {
+		fmt.Fprintf(os.Stderr, "Error fetching servers: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(m.ServerList) == 0 {
+		fmt.Println("No servers found.")
+		return
+	}
+
+	switch serversFormat {
+	case serversFormatJSON:
+		entries := make([]serverEntry, len(m.ServerList))
+		for i, s := range m.ServerList {
+			entries[i] = serverEntry{
+				ID:       s.ID,
+				Name:     s.Name,
+				Sponsor:  s.Sponsor,
+				Country:  s.Country,
+				Latency:  s.Latency.Seconds() * 1000,
+				Distance: s.Distance,
+			}
+		}
+		data, err := json.MarshalIndent(entries, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error serialising servers: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(data))
+
+	case serversFormatCSV:
+		w := csv.NewWriter(os.Stdout)
+		_ = w.Write([]string{"id", "name", "sponsor", "country", "latency_ms", "distance_km"})
+		for _, s := range m.ServerList {
+			_ = w.Write([]string{
+				s.ID,
+				s.Name,
+				s.Sponsor,
+				s.Country,
+				fmt.Sprintf("%.2f", s.Latency.Seconds()*1000),
+				fmt.Sprintf("%.1f", s.Distance),
+			})
+		}
+		w.Flush()
+
+	default:
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "ID\tNAME\tSPONSOR\tCOUNTRY\tLATENCY (ms)\tDISTANCE (km)")
+		for _, s := range m.ServerList {
+			name := s.Name
+			if len(name) > 30 {
+				name = name[:27] + "..."
+			}
+			sponsor := s.Sponsor
+			if len(sponsor) > 20 {
+				sponsor = sponsor[:17] + "..."
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%.2f\t%.1f\n",
+				s.ID, name, sponsor, s.Country,
+				s.Latency.Seconds()*1000, s.Distance)
+		}
+		w.Flush()
+	}
+}
+
+func init() {
+	serversCmd.Flags().StringVar(&serversFormat, "format", "", "Output format: json or csv (default: table)")
+	rootCmd.AddCommand(serversCmd)
+}

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -27,7 +27,7 @@ func TestVersionCommand(t *testing.T) {
 
 // We just ensure the commands exist and are wired up properly.
 func TestCommandsConfigured(t *testing.T) {
-	var foundVersion, foundRun, foundHistory bool
+	var foundVersion, foundRun, foundHistory, foundServers bool
 	for _, cmd := range rootCmd.Commands() {
 		switch cmd.Name() {
 		case "version":
@@ -36,6 +36,8 @@ func TestCommandsConfigured(t *testing.T) {
 			foundRun = true
 		case "history":
 			foundHistory = true
+		case "servers":
+			foundServers = true
 		}
 	}
 
@@ -47,6 +49,9 @@ func TestCommandsConfigured(t *testing.T) {
 	}
 	if !foundHistory {
 		t.Error("history command not registered")
+	}
+	if !foundServers {
+		t.Error("servers command not registered")
 	}
 }
 
@@ -521,5 +526,22 @@ func TestRunCommandValidation(t *testing.T) {
 	err = runCmd.PreRunE(nil, nil)
 	if err != nil {
 		t.Errorf("Expected nil error for valid count, got %v", err)
+	}
+}
+
+func TestServersCommandValidation(t *testing.T) {
+	origFormat := serversFormat
+	defer func() { serversFormat = origFormat }()
+
+	serversFormat = "xml"
+	err := serversCmd.RunE(nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid --format") {
+		t.Errorf("Expected 'invalid --format' error, got %v", err)
+	}
+
+	serversFormat = "yaml"
+	err = serversCmd.RunE(nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid --format") {
+		t.Errorf("Expected 'invalid --format' error for yaml, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Adds `lazyspeed servers` to list available speed test servers, enabling discovery of server IDs for use with `lazyspeed run --server <id>`. Previously, the `--server` flag was a dead end since users had no way to find valid IDs.

## Changes

**Features**
- `lazyspeed servers` command with table output (default), `--format json`, and `--format csv`
- Columns: ID, Name, Sponsor, Country, Latency (ms), Distance (km)
- Clean `serverEntry` struct for JSON/CSV serialization, decoupled from speedtest-go internals

## Testing

- `TestCommandsConfigured` updated to verify `servers` registration
- `TestServersCommandValidation` validates `--format` flag rejection for invalid values
- `go vet`, `go test -race ./...`, `go build` all pass