### PR TITLE
fix: drain body, ANSI width, target validation, DNS budget

### DIFF
--- a/diag/diag.go
+++ b/diag/diag.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/jkleinne/lazyspeed/internal/timeutil"
@@ -139,6 +140,11 @@ func NewConfig(overrides Config) *Config {
 func Run(ctx context.Context, backend Backend, target string, cfg *Config) (*Result, error) {
 	if cfg == nil {
 		cfg = DefaultConfig()
+	}
+
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return nil, fmt.Errorf("target must not be empty")
 	}
 
 	result := &Result{

--- a/diag/diag_test.go
+++ b/diag/diag_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 )
@@ -475,6 +476,31 @@ func TestRunContextCancelledBetweenDNSAndTraceroute(t *testing.T) {
 	_, err := Run(ctx, backend, testExampleHost, DefaultConfig())
 	if err == nil {
 		t.Fatal("expected error from context cancellation between DNS and traceroute")
+	}
+}
+
+func TestRunEmptyTarget(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+	}{
+		{"empty string", ""},
+		{"whitespace only", "   "},
+		{"tabs and newlines", "\t\n"},
+	}
+
+	backend := &mockBackend{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Run(context.Background(), backend, tt.target, DefaultConfig())
+			if err == nil {
+				t.Fatal("expected error for empty target")
+			}
+			if !strings.Contains(err.Error(), "target must not be empty") {
+				t.Errorf("unexpected error message: %v", err)
+			}
+		})
 	}
 }
 

--- a/diag/traceroute.go
+++ b/diag/traceroute.go
@@ -121,7 +121,7 @@ func traceLoop(ctx context.Context, destIP string, maxHops int, hopFn func(ttl i
 
 // readICMPResponse reads an ICMP response from conn, parses it, and populates the hop
 // if the response type matches one of validTypes. Returns false if any step fails.
-func readICMPResponse(ctx context.Context, conn *icmp.PacketConn, start time.Time, hop *Hop, rdns *reverseDNS, validTypes ...icmp.Type) bool {
+func readICMPResponse(conn *icmp.PacketConn, start time.Time, hop *Hop, rdns *reverseDNS, validTypes ...icmp.Type) bool {
 	buf := make([]byte, maxPacketSize)
 	n, peer, err := conn.ReadFrom(buf)
 	latency := time.Since(start)
@@ -186,7 +186,7 @@ func awaitHopResponse(ctx context.Context, conn *icmp.PacketConn, hop *Hop, star
 		hop.Timeout = true
 		return *hop
 	}
-	if !readICMPResponse(ctx, conn, start, hop, rdns, validTypes...) {
+	if !readICMPResponse(conn, start, hop, rdns, validTypes...) {
 		hop.Timeout = true
 	}
 	return *hop

--- a/diag/traceroute.go
+++ b/diag/traceroute.go
@@ -99,6 +99,7 @@ const (
 	icmpIDMask         = 0xffff // ICMP Echo ID field is 16-bit
 	maxPacketSize      = 1500
 	icmpProtocol       = 1
+	reverseDNSBudget   = 10 * time.Second
 )
 
 // traceLoop runs a traceroute loop, calling hopFn for each TTL until the destination
@@ -120,7 +121,7 @@ func traceLoop(ctx context.Context, destIP string, maxHops int, hopFn func(ttl i
 
 // readICMPResponse reads an ICMP response from conn, parses it, and populates the hop
 // if the response type matches one of validTypes. Returns false if any step fails.
-func readICMPResponse(ctx context.Context, conn *icmp.PacketConn, start time.Time, hop *Hop, validTypes ...icmp.Type) bool {
+func readICMPResponse(ctx context.Context, conn *icmp.PacketConn, start time.Time, hop *Hop, rdns *reverseDNS, validTypes ...icmp.Type) bool {
 	buf := make([]byte, maxPacketSize)
 	n, peer, err := conn.ReadFrom(buf)
 	latency := time.Since(start)
@@ -141,7 +142,7 @@ func readICMPResponse(ctx context.Context, conn *icmp.PacketConn, start time.Tim
 	for _, t := range validTypes {
 		if rm.Type == t {
 			hop.IP = peerIP
-			hop.Host = reverseResolve(ctx, peerIP)
+			hop.Host = rdns.resolve(peerIP)
 			hop.Latency = latency
 			return true
 		}
@@ -159,8 +160,12 @@ func icmpTraceroute(ctx context.Context, destIP string, maxHops int) ([]Hop, err
 	}
 	defer func() { _ = conn.Close() }()
 
+	dnsCtx, dnsCancel := context.WithTimeout(ctx, reverseDNSBudget)
+	defer dnsCancel()
+	rdns := &reverseDNS{ctx: dnsCtx, resolver: &net.Resolver{}}
+
 	return traceLoop(ctx, destIP, maxHops, func(ttl int) Hop {
-		return traceHop(ctx, conn, destIP, ttl)
+		return traceHop(ctx, conn, destIP, ttl, rdns)
 	}), nil
 }
 
@@ -176,19 +181,19 @@ func setHopDeadline(ctx context.Context, conn *icmp.PacketConn) error {
 
 // awaitHopResponse sets the read deadline and waits for an ICMP response,
 // populating the hop on success. Returns the hop with Timeout=true on failure.
-func awaitHopResponse(ctx context.Context, conn *icmp.PacketConn, hop *Hop, start time.Time, validTypes ...icmp.Type) Hop {
+func awaitHopResponse(ctx context.Context, conn *icmp.PacketConn, hop *Hop, start time.Time, rdns *reverseDNS, validTypes ...icmp.Type) Hop {
 	if err := setHopDeadline(ctx, conn); err != nil {
 		hop.Timeout = true
 		return *hop
 	}
-	if !readICMPResponse(ctx, conn, start, hop, validTypes...) {
+	if !readICMPResponse(ctx, conn, start, hop, rdns, validTypes...) {
 		hop.Timeout = true
 	}
 	return *hop
 }
 
 // traceHop sends an ICMP echo request with the given TTL and waits for a response.
-func traceHop(ctx context.Context, conn *icmp.PacketConn, destIP string, ttl int) Hop {
+func traceHop(ctx context.Context, conn *icmp.PacketConn, destIP string, ttl int, rdns *reverseDNS) Hop {
 	hop := Hop{Number: ttl}
 
 	// Setup errors (SetTTL, Marshal, WriteTo) are treated as timeouts — the user
@@ -222,7 +227,7 @@ func traceHop(ctx context.Context, conn *icmp.PacketConn, destIP string, ttl int
 		return hop
 	}
 
-	return awaitHopResponse(ctx, conn, &hop, start, ipv4.ICMPTypeEchoReply, ipv4.ICMPTypeTimeExceeded)
+	return awaitHopResponse(ctx, conn, &hop, start, rdns, ipv4.ICMPTypeEchoReply, ipv4.ICMPTypeTimeExceeded)
 }
 
 // udpTraceroute performs traceroute using UDP packets with increasing TTL,
@@ -234,14 +239,18 @@ func udpTraceroute(ctx context.Context, destIP string, maxHops int) ([]Hop, erro
 	}
 	defer func() { _ = icmpConn.Close() }()
 
+	dnsCtx, dnsCancel := context.WithTimeout(ctx, reverseDNSBudget)
+	defer dnsCancel()
+	rdns := &reverseDNS{ctx: dnsCtx, resolver: &net.Resolver{}}
+
 	return traceLoop(ctx, destIP, maxHops, func(ttl int) Hop {
-		return udpTraceHop(ctx, icmpConn, destIP, ttl)
+		return udpTraceHop(ctx, icmpConn, destIP, ttl, rdns)
 	}), nil
 }
 
 // udpTraceHop sends a UDP packet to tracerouteBasePort+ttl with a specific TTL
 // and listens for an ICMP TTL Exceeded response.
-func udpTraceHop(ctx context.Context, icmpConn *icmp.PacketConn, destIP string, ttl int) Hop {
+func udpTraceHop(ctx context.Context, icmpConn *icmp.PacketConn, destIP string, ttl int, rdns *reverseDNS) Hop {
 	hop := Hop{Number: ttl}
 
 	// Setup errors (DialUDP, SyscallConn, setsockopt, Write) are treated as
@@ -285,20 +294,26 @@ func udpTraceHop(ctx context.Context, icmpConn *icmp.PacketConn, destIP string, 
 		return hop
 	}
 
-	return awaitHopResponse(ctx, icmpConn, &hop, start, ipv4.ICMPTypeTimeExceeded, ipv4.ICMPTypeDestinationUnreachable)
+	return awaitHopResponse(ctx, icmpConn, &hop, start, rdns, ipv4.ICMPTypeTimeExceeded, ipv4.ICMPTypeDestinationUnreachable)
 }
 
-// reverseResolve does best-effort reverse DNS lookup for an IP address.
-// Returns the IP string if reverse lookup fails.
-func reverseResolve(ctx context.Context, ip string) string {
-	lookupCtx, cancel := context.WithTimeout(ctx, reverseDNSTimeout)
+// reverseDNS holds shared state for reverse DNS lookups across a traceroute run.
+// A single budget context caps total DNS time, and a shared resolver avoids
+// per-hop allocation overhead.
+type reverseDNS struct {
+	ctx      context.Context
+	resolver *net.Resolver
+}
+
+// resolve does best-effort reverse DNS lookup for an IP address.
+// Returns the IP string if the budget is exhausted or the lookup fails.
+func (r *reverseDNS) resolve(ip string) string {
+	lookupCtx, cancel := context.WithTimeout(r.ctx, reverseDNSTimeout)
 	defer cancel()
 
-	resolver := &net.Resolver{}
-	names, err := resolver.LookupAddr(lookupCtx, ip)
+	names, err := r.resolver.LookupAddr(lookupCtx, ip)
 	if err != nil || len(names) == 0 {
 		return ip
 	}
-	// Remove trailing dot from DNS name
 	return strings.TrimSuffix(names[0], ".")
 }

--- a/diag/traceroute_test.go
+++ b/diag/traceroute_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"testing"
 	"time"
@@ -105,5 +106,62 @@ func TestIsPermissionError(t *testing.T) {
 				t.Errorf("isPermissionError(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestReverseDNSBudgetBoundsTotal(t *testing.T) {
+	budget := 500 * time.Millisecond
+	perLookup := 200 * time.Millisecond
+	totalCalls := 10
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	dnsCtx, dnsCancel := context.WithTimeout(ctx, budget)
+	defer dnsCancel()
+
+	slowResolver := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			select {
+			case <-time.After(perLookup):
+				return nil, fmt.Errorf("simulated slow DNS")
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	}
+
+	rdns := &reverseDNS{ctx: dnsCtx, resolver: slowResolver}
+
+	var callDurations []time.Duration
+	start := time.Now()
+	for i := range totalCalls {
+		callStart := time.Now()
+		ip := fmt.Sprintf("10.0.0.%d", i+1)
+		result := rdns.resolve(ip)
+		callDurations = append(callDurations, time.Since(callStart))
+
+		if result != ip {
+			t.Errorf("call %d: expected raw IP %q, got %q", i, ip, result)
+		}
+	}
+	elapsed := time.Since(start)
+
+	if elapsed > budget+300*time.Millisecond {
+		t.Errorf("total time %v exceeds budget %v by too much", elapsed, budget)
+	}
+
+	var fastCalls int
+	for _, d := range callDurations {
+		if d < 50*time.Millisecond {
+			fastCalls++
+		}
+	}
+	if fastCalls == 0 {
+		t.Error("expected some calls to return instantly after budget exhaustion")
+	}
+	if fastCalls == totalCalls {
+		t.Error("expected some calls to block before budget exhaustion")
 	}
 }

--- a/notify/deliver.go
+++ b/notify/deliver.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -86,13 +87,18 @@ func deliverOne(ctx context.Context, sender Sender, ep model.WebhookEndpoint, bo
 		}
 
 		resp, err := sender.Do(req)
-		reqCancel()
-
 		if err != nil {
+			reqCancel()
 			lastErr = fmt.Errorf("request failed: %v", err)
 			continue
 		}
+
+		// Drain body before closing to allow HTTP connection reuse.
+		// Drain errors are safe to ignore: failure just means the
+		// connection won't be reused, which is a performance detail.
+		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
+		reqCancel()
 
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 			return nil

--- a/notify/deliver_test.go
+++ b/notify/deliver_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -325,5 +326,61 @@ func TestDispatch_NoThresholdsAlwaysFires(t *testing.T) {
 	}
 	if p.Event != EventTestComplete {
 		t.Errorf("expected event %q for no thresholds, got %q", EventTestComplete, p.Event)
+	}
+}
+
+// trackingReader wraps an io.Reader and calls onEOF exactly once when Read returns io.EOF.
+// Used in tests to verify the response body is fully consumed before Close is called.
+type trackingReader struct {
+	io.Reader
+	onEOF  func()
+	hitEOF bool
+}
+
+func (r *trackingReader) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	if err == io.EOF && !r.hitEOF {
+		r.hitEOF = true
+		if r.onEOF != nil {
+			r.onEOF()
+		}
+	}
+	return n, err
+}
+
+func TestDeliver_DrainsResponseBody(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{"2xx drains body", http.StatusOK},
+		{"5xx drains body", http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bodyContent := "response payload"
+			drained := false
+
+			sender := &mockSender{
+				doFn: func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: tt.status,
+						Body: io.NopCloser(&trackingReader{
+							Reader: strings.NewReader(bodyContent),
+							onEOF:  func() { drained = true },
+						}),
+					}, nil
+				},
+			}
+
+			endpoints := []model.WebhookEndpoint{{URL: "http://example.com/hook"}}
+			payload := NewPayload(&model.SpeedTestResult{}, nil, "1.0.0", time.Now())
+			Deliver(context.Background(), sender, endpoints, payload, 5*time.Second, 1)
+
+			if !drained {
+				t.Errorf("response body was not drained for status %d", tt.status)
+			}
+		})
 	}
 }

--- a/ui/diag.go
+++ b/ui/diag.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/jkleinne/lazyspeed/diag"
 	"github.com/jkleinne/lazyspeed/internal/timeutil"
 )
@@ -233,9 +234,9 @@ func renderHopRow(hop diag.Hop, absoluteIndex int) string {
 		latStr,
 	)
 
-	rowRunes := []rune(row)
-	if len(rowRunes) < hopTableWidth {
-		row += strings.Repeat(" ", hopTableWidth-len(rowRunes))
+	w := ansi.StringWidth(row)
+	if w < hopTableWidth {
+		row += strings.Repeat(" ", hopTableWidth-w)
 	}
 
 	if absoluteIndex%2 == 0 {

--- a/ui/diag_test.go
+++ b/ui/diag_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/jkleinne/lazyspeed/diag"
 )
 
@@ -356,5 +357,24 @@ func TestScoreStyle(t *testing.T) {
 				t.Error("expected styled output to differ from plain text")
 			}
 		})
+	}
+}
+
+func TestRenderHopRowVisualWidth(t *testing.T) {
+	hop := diag.Hop{
+		Number:  3,
+		IP:      "10.0.0.1",
+		Host:    "gateway.local",
+		Latency: 25 * time.Millisecond,
+	}
+
+	rendered := renderHopRow(hop, 0)
+	// Strip the outer row style (diagEvenRowStyle/diagOddRowStyle) to measure
+	// the inner content width. The row styles only add foreground/background
+	// color, not padding or margins, so stripping ANSI gives us the plain text
+	// whose length equals the visual width before row styling.
+	plain := ansi.Strip(rendered)
+	if len([]rune(plain)) != hopTableWidth {
+		t.Errorf("visual width = %d, want %d", len([]rune(plain)), hopTableWidth)
 	}
 }


### PR DESCRIPTION
## Summary

- **HTTP body drain** (`notify/deliver.go`): response body is now drained before close, with `reqCancel()` moved after the drain so the request context stays active during the read. Fixes connection pool churn in `--watch` and multi-server dispatch.
- **ANSI row width** (`ui/diag.go`): hop table padding now uses `ansi.StringWidth` instead of rune count, so ANSI escape codes in styled latency text no longer inflate the width calculation.
- **Empty target validation** (`diag/diag.go`): `Run()` rejects empty or whitespace-only targets with a clear error instead of falling through to confusing DNS failures.
- **Reverse DNS budget** (`diag/traceroute.go`): a shared `reverseDNS` struct caps total reverse DNS time at 10 seconds across all hops. After budget exhaustion, lookups return the raw IP instantly instead of blocking. Also reuses a single `net.Resolver` per traceroute run.