### PR TITLE
Add InfluxDB metrics export (v1 and v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,26 @@ export:
 
 All settings are optional: sensible defaults are used when omitted.
 
+### InfluxDB export
+
+Push speed test results to InfluxDB (v1 or v2) for graphing in Grafana. Configure one or more endpoints in `~/.config/lazyspeed/config.yaml`:
+
+```yaml
+metrics:
+  endpoints:
+    - url: "https://influx.example.com:8086"
+      v2:
+        token: "your-influx-token"
+        org: "my-org"
+        bucket: "speedtest"
+  timeout: 10
+  max_retries: 1
+```
+
+For InfluxDB v1, use a `v1:` block with `database`, optional `username`, and optional `password` instead. Exactly one of `v1:` or `v2:` must be set per endpoint.
+
+Metrics writes fire after every successful speed test in both headless (`lazyspeed run`) and interactive (TUI) modes. Failures are logged as warnings and do not fail the test itself.
+
 ## Comparison
 
 | Feature | LazySpeed | Ookla CLI | fast-cli | speedtest-go CLI |

--- a/cmd_run.go
+++ b/cmd_run.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/jkleinne/lazyspeed/metrics"
 	"github.com/jkleinne/lazyspeed/model"
 	"github.com/jkleinne/lazyspeed/notify"
 	"github.com/jkleinne/lazyspeed/ui"
@@ -64,6 +65,11 @@ var runF runFlags
 // combining config-file endpoints with any --webhook-url flag value.
 // Initialized by runHeadlessTest before any sub-function reads it.
 var webhookCfg model.WebhookConfig
+
+// metricsCfg holds the merged metrics export configuration for the current
+// headless run. Read by dispatchResultSinks in place of threading Config
+// through every call site. Mirrors webhookCfg.
+var metricsCfg model.MetricsConfig
 
 var runCmd = &cobra.Command{
 	Use:   "run",
@@ -318,7 +324,7 @@ func runMultiServerHeadless(m *model.Model, interactive bool) {
 	})
 
 	for _, res := range results {
-		dispatchWebhooks(context.Background(), webhookCfg, res)
+		dispatchResultSinks(context.Background(), res)
 	}
 }
 
@@ -388,6 +394,7 @@ func runHeadlessTest() {
 			model.WebhookEndpoint{URL: runF.webhookURL},
 		)
 	}
+	metricsCfg = m.Config.Metrics
 
 	if runF.best > 0 || runF.serverIDs != "" || runF.favorites {
 		runMultiServerHeadless(m, interactive)
@@ -430,16 +437,25 @@ func recordResult(m *model.Model, res *model.SpeedTestResult) {
 	}
 }
 
-// dispatchWebhooks sends the result to configured webhook endpoints.
-// Errors are printed as warnings to stderr and do not affect the test result.
-func dispatchWebhooks(ctx context.Context, cfg model.WebhookConfig, result *model.SpeedTestResult) {
-	if len(cfg.Endpoints) == 0 {
-		return
-	}
+// dispatchResultSinks fans the result out to all configured result sinks
+// (webhooks and InfluxDB metrics). Each sink runs independently; errors
+// from either are printed as warnings to stderr and do not affect the
+// test result.
+func dispatchResultSinks(ctx context.Context, result *model.SpeedTestResult) {
 	client := &http.Client{}
-	errs := notify.Dispatch(ctx, client, cfg, result, version)
-	for _, e := range errs {
-		fmt.Fprintf(os.Stderr, "Warning: webhook delivery to %s failed: %v\n", e.URL, e.Err)
+
+	if len(webhookCfg.Endpoints) > 0 {
+		errs := notify.Dispatch(ctx, client, webhookCfg, result, version)
+		for _, e := range errs {
+			fmt.Fprintf(os.Stderr, "Warning: webhook delivery to %s failed: %v\n", e.URL, e.Err)
+		}
+	}
+
+	if len(metricsCfg.Endpoints) > 0 {
+		errs := metrics.Dispatch(ctx, client, metricsCfg, result)
+		for _, e := range errs {
+			fmt.Fprintf(os.Stderr, "Warning: metrics write to %s failed: %v\n", e.URL, e.Err)
+		}
 	}
 }
 
@@ -494,7 +510,7 @@ func runCountLoop(m *model.Model, server *speedtest.Server, opts model.RunOption
 			exitWithError("running test: %v", err)
 		}
 
-		dispatchWebhooks(context.Background(), webhookCfg, res)
+		dispatchResultSinks(context.Background(), res)
 
 		switch {
 		case runF.json:
@@ -546,7 +562,7 @@ func runWatchLoop(m *model.Model, server *speedtest.Server, opts model.RunOption
 			fmt.Fprintf(os.Stderr, "Error: running test: %v\n", err)
 		} else {
 			recordResult(m, res)
-			dispatchWebhooks(context.Background(), webhookCfg, res)
+			dispatchResultSinks(context.Background(), res)
 			emitWatchResult(res)
 		}
 

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jkleinne/lazyspeed/diag"
+	"github.com/jkleinne/lazyspeed/metrics"
 	"github.com/jkleinne/lazyspeed/model"
 	"github.com/jkleinne/lazyspeed/notify"
 	"github.com/jkleinne/lazyspeed/ui"
@@ -28,9 +29,12 @@ type exportDoneMsg struct {
 	err  error
 }
 
-// webhookDoneMsg is sent when background webhook delivery completes.
-type webhookDoneMsg struct {
-	errs []notify.DeliveryError
+// resultSinksDoneMsg is sent when background result-sink delivery completes.
+// Carries separate error slices for each sink so the reducer can label
+// failures by source.
+type resultSinksDoneMsg struct {
+	webhookErrs []notify.DeliveryError
+	metricsErrs []metrics.WriteError
 }
 
 const (
@@ -254,13 +258,24 @@ func (s *speedTest) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return s, nil
 
-	case webhookDoneMsg:
-		if len(msg.errs) > 0 {
-			warnings := make([]string, len(msg.errs))
-			for i, e := range msg.errs {
-				warnings[i] = e.Error()
+	case resultSinksDoneMsg:
+		var warnings []string
+		if len(msg.webhookErrs) > 0 {
+			webhookMessages := make([]string, len(msg.webhookErrs))
+			for i, e := range msg.webhookErrs {
+				webhookMessages[i] = e.Error()
 			}
-			s.model.Warning = fmt.Sprintf("Webhook: %s", strings.Join(warnings, "; "))
+			warnings = append(warnings, fmt.Sprintf("Webhook: %s", strings.Join(webhookMessages, "; ")))
+		}
+		if len(msg.metricsErrs) > 0 {
+			metricsMessages := make([]string, len(msg.metricsErrs))
+			for i, e := range msg.metricsErrs {
+				metricsMessages[i] = e.Error()
+			}
+			warnings = append(warnings, fmt.Sprintf("Metrics: %s", strings.Join(metricsMessages, "; ")))
+		}
+		if len(warnings) > 0 {
+			s.model.Warning = strings.Join(warnings, " | ")
 		}
 		return s, nil
 
@@ -351,8 +366,8 @@ func (s *speedTest) handleTestComplete(msg testComplete) (tea.Model, tea.Cmd) {
 		s.model.History.Results = nil
 		return s, nil
 	}
-	if s.model.History.Results != nil && len(s.model.Config.Webhooks.Endpoints) > 0 {
-		return s, webhookCmd(s.model.Config.Webhooks, s.model.History.Results)
+	if s.model.History.Results != nil && sinksConfigured(s.model.Config) {
+		return s, resultSinksCmd(s.model.Config, s.model.History.Results)
 	}
 	return s, nil
 }
@@ -851,10 +866,10 @@ func (s *speedTest) handleMultiServerComplete(msg multiServerCompleteMsg) (tea.M
 	s.selectedServers = nil
 	s.viewState = ViewComparison
 
-	if len(s.model.Config.Webhooks.Endpoints) > 0 && len(msg.results) > 0 {
+	if sinksConfigured(s.model.Config) && len(msg.results) > 0 {
 		cmds := make([]tea.Cmd, len(msg.results))
 		for i, res := range msg.results {
-			cmds[i] = webhookCmd(s.model.Config.Webhooks, res)
+			cmds[i] = resultSinksCmd(s.model.Config, res)
 		}
 		return s, tea.Batch(cmds...)
 	}
@@ -905,13 +920,23 @@ func exportCmd(result *model.SpeedTestResult, format string, m *model.Model) tea
 	}
 }
 
-// webhookCmd dispatches webhook notifications in a goroutine and returns the result as a tea.Cmd.
-func webhookCmd(cfg model.WebhookConfig, result *model.SpeedTestResult) tea.Cmd {
+// resultSinksCmd dispatches webhooks and metrics writes in a goroutine and
+// returns the combined result as a tea.Cmd. Both sinks run sequentially
+// inside the goroutine; neither blocks the TUI thread.
+func resultSinksCmd(cfg *model.Config, result *model.SpeedTestResult) tea.Cmd {
 	return func() tea.Msg {
 		client := &http.Client{}
-		errs := notify.Dispatch(context.Background(), client, cfg, result, version)
-		return webhookDoneMsg{errs: errs}
+		webhookErrs := notify.Dispatch(context.Background(), client, cfg.Webhooks, result, version)
+		metricsErrs := metrics.Dispatch(context.Background(), client, cfg.Metrics, result)
+		return resultSinksDoneMsg{webhookErrs: webhookErrs, metricsErrs: metricsErrs}
 	}
+}
+
+// sinksConfigured reports whether at least one result sink (webhook or
+// metrics) has endpoints configured. Used by the TUI post-test branches
+// to decide whether to fire resultSinksCmd at all.
+func sinksConfigured(cfg *model.Config) bool {
+	return len(cfg.Webhooks.Endpoints) > 0 || len(cfg.Metrics.Endpoints) > 0
 }
 
 func migrateHistoryIfNeeded() {

--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jkleinne/lazyspeed/diag"
+	"github.com/jkleinne/lazyspeed/metrics"
 	"github.com/jkleinne/lazyspeed/model"
+	"github.com/jkleinne/lazyspeed/notify"
 	"github.com/jkleinne/lazyspeed/ui"
 	"github.com/showwin/speedtest-go/speedtest"
 )
@@ -251,6 +253,97 @@ func TestUpdateExportDoneMsgError(t *testing.T) {
 
 	if !strings.Contains(newS.model.ExportMessage, "write failed") {
 		t.Errorf("Expected error text in ExportMessage, got %q", newS.model.ExportMessage)
+	}
+}
+
+func TestUpdateResultSinksDoneMsg_BothEmpty(t *testing.T) {
+	m := model.NewDefaultModel()
+	m.Warning = "preexisting"
+	s := speedTest{model: m, spinner: ui.DefaultSpinner}
+
+	newModel, _ := s.Update(resultSinksDoneMsg{})
+	newS := newModel.(*speedTest)
+
+	if newS.model.Warning != "preexisting" {
+		t.Errorf("Expected Warning to be preserved when no sink errored, got %q", newS.model.Warning)
+	}
+}
+
+func TestUpdateResultSinksDoneMsg_WebhookErrorsOnly(t *testing.T) {
+	m := model.NewDefaultModel()
+	s := speedTest{model: m, spinner: ui.DefaultSpinner}
+
+	msg := resultSinksDoneMsg{
+		webhookErrs: []notify.DeliveryError{
+			{URL: "https://hooks.example.com", Err: errors.New("connection refused")},
+		},
+	}
+	newModel, _ := s.Update(msg)
+	newS := newModel.(*speedTest)
+
+	if !strings.HasPrefix(newS.model.Warning, "Webhook: ") {
+		t.Errorf("Expected Warning to start with \"Webhook: \", got %q", newS.model.Warning)
+	}
+	if !strings.Contains(newS.model.Warning, "connection refused") {
+		t.Errorf("Expected error text in Warning, got %q", newS.model.Warning)
+	}
+	if strings.Contains(newS.model.Warning, "Metrics:") {
+		t.Errorf("Did not expect Metrics prefix when only webhook errored, got %q", newS.model.Warning)
+	}
+}
+
+func TestUpdateResultSinksDoneMsg_MetricsErrorsOnly(t *testing.T) {
+	m := model.NewDefaultModel()
+	s := speedTest{model: m, spinner: ui.DefaultSpinner}
+
+	msg := resultSinksDoneMsg{
+		metricsErrs: []metrics.WriteError{
+			{URL: "https://influx.example.com", Err: errors.New("status 500")},
+		},
+	}
+	newModel, _ := s.Update(msg)
+	newS := newModel.(*speedTest)
+
+	if !strings.HasPrefix(newS.model.Warning, "Metrics: ") {
+		t.Errorf("Expected Warning to start with \"Metrics: \", got %q", newS.model.Warning)
+	}
+	if !strings.Contains(newS.model.Warning, "status 500") {
+		t.Errorf("Expected error text in Warning, got %q", newS.model.Warning)
+	}
+	if strings.Contains(newS.model.Warning, "Webhook:") {
+		t.Errorf("Did not expect Webhook prefix when only metrics errored, got %q", newS.model.Warning)
+	}
+}
+
+func TestUpdateResultSinksDoneMsg_BothHaveErrors(t *testing.T) {
+	m := model.NewDefaultModel()
+	s := speedTest{model: m, spinner: ui.DefaultSpinner}
+
+	msg := resultSinksDoneMsg{
+		webhookErrs: []notify.DeliveryError{
+			{URL: "https://hooks.example.com", Err: errors.New("timeout")},
+		},
+		metricsErrs: []metrics.WriteError{
+			{URL: "https://influx.example.com", Err: errors.New("unauthorized")},
+		},
+	}
+	newModel, _ := s.Update(msg)
+	newS := newModel.(*speedTest)
+
+	if !strings.Contains(newS.model.Warning, "Webhook: ") {
+		t.Errorf("Expected Webhook prefix in Warning, got %q", newS.model.Warning)
+	}
+	if !strings.Contains(newS.model.Warning, "Metrics: ") {
+		t.Errorf("Expected Metrics prefix in Warning, got %q", newS.model.Warning)
+	}
+	if !strings.Contains(newS.model.Warning, " | ") {
+		t.Errorf("Expected cross-sink separator \" | \" in Warning, got %q", newS.model.Warning)
+	}
+	if !strings.Contains(newS.model.Warning, "timeout") {
+		t.Errorf("Expected webhook error text in Warning, got %q", newS.model.Warning)
+	}
+	if !strings.Contains(newS.model.Warning, "unauthorized") {
+		t.Errorf("Expected metrics error text in Warning, got %q", newS.model.Warning)
 	}
 }
 

--- a/metrics/dispatch.go
+++ b/metrics/dispatch.go
@@ -1,0 +1,52 @@
+package metrics
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/jkleinne/lazyspeed/model"
+)
+
+// Dispatch is the top-level entry point for InfluxDB metrics export.
+// It encodes the result once, then writes sequentially to each configured
+// endpoint. Returns nil if no endpoints are configured; otherwise returns
+// a slice of WriteError for every endpoint that failed. Per-endpoint
+// failures do not abort delivery to subsequent endpoints.
+//
+// A cancelled context aborts at the next delivery attempt.
+func Dispatch(ctx context.Context, sender Sender, cfg model.MetricsConfig, result *model.SpeedTestResult) []WriteError {
+	if len(cfg.Endpoints) == 0 {
+		return nil
+	}
+
+	host := resolveHost(cfg)
+	body := EncodePoint(result, host)
+	timeout := time.Duration(cfg.Timeout) * time.Second
+
+	var errs []WriteError
+	for _, ep := range cfg.Endpoints {
+		if err := writeOne(ctx, sender, ep, body, timeout, cfg.MaxRetries); err != nil {
+			errs = append(errs, WriteError{URL: ep.URL, Err: err})
+		}
+	}
+	return errs
+}
+
+// resolveHost returns the host tag value based on the config. OmitHostTag
+// or an os.Hostname() failure returns the empty string, which the encoder
+// treats as "omit the host tag entirely". Users who want a literal
+// fallback label (e.g., "unknown") can set HostTag explicitly.
+func resolveHost(cfg model.MetricsConfig) string {
+	if cfg.OmitHostTag {
+		return ""
+	}
+	if cfg.HostTag != "" {
+		return cfg.HostTag
+	}
+	host, err := os.Hostname()
+	if err != nil {
+		return ""
+	}
+	return host
+}

--- a/metrics/dispatch_test.go
+++ b/metrics/dispatch_test.go
@@ -1,0 +1,109 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jkleinne/lazyspeed/model"
+)
+
+func TestDispatch_NoEndpoints(t *testing.T) {
+	errs := Dispatch(context.Background(), &mockSender{}, model.MetricsConfig{}, &model.SpeedTestResult{})
+	if errs != nil {
+		t.Errorf("expected nil for no endpoints, got %v", errs)
+	}
+}
+
+func TestDispatch_SingleSuccess(t *testing.T) {
+	var capturedBody []byte
+	sender := &mockSender{DoFn: func(req *http.Request) (*http.Response, error) {
+		capturedBody, _ = io.ReadAll(req.Body)
+		return &http.Response{StatusCode: 204, Body: io.NopCloser(strings.NewReader(""))}, nil
+	}}
+	cfg := model.MetricsConfig{
+		Endpoints: []model.MetricsEndpoint{
+			{URL: "https://example.com", V2: &model.InfluxV2{Token: "t", Org: "o", Bucket: "b"}},
+		},
+		Timeout:    10,
+		MaxRetries: 1,
+		HostTag:    "h1",
+	}
+	result := &model.SpeedTestResult{
+		DownloadSpeed: 100,
+		ServerName:    "srv",
+		Timestamp:     time.Unix(1712761200, 0),
+	}
+	errs := Dispatch(context.Background(), sender, cfg, result)
+	if errs != nil {
+		t.Errorf("expected no errors, got %v", errs)
+	}
+	if !strings.Contains(string(capturedBody), "host=h1") {
+		t.Errorf("expected host tag in body, got %q", capturedBody)
+	}
+	if !strings.Contains(string(capturedBody), "download_mbps=100") {
+		t.Errorf("expected download field, got %q", capturedBody)
+	}
+}
+
+func TestDispatch_OneSucceedsOneFails(t *testing.T) {
+	call := 0
+	sender := &mockSender{DoFn: func(req *http.Request) (*http.Response, error) {
+		call++
+		if call == 1 {
+			return &http.Response{StatusCode: 204, Body: io.NopCloser(strings.NewReader(""))}, nil
+		}
+		return nil, errors.New("boom")
+	}}
+	cfg := model.MetricsConfig{
+		Endpoints: []model.MetricsEndpoint{
+			{URL: "https://ok.example.com", V2: &model.InfluxV2{Token: "t", Org: "o", Bucket: "b"}},
+			{URL: "https://bad.example.com", V2: &model.InfluxV2{Token: "t", Org: "o", Bucket: "b"}},
+		},
+		Timeout:    1,
+		MaxRetries: 1,
+	}
+	errs := Dispatch(context.Background(), sender, cfg, &model.SpeedTestResult{Timestamp: time.Unix(1, 0)})
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+	if errs[0].URL != "https://bad.example.com" {
+		t.Errorf("wrong URL on error: %q", errs[0].URL)
+	}
+}
+
+func TestDispatch_OmitHostTag(t *testing.T) {
+	var body []byte
+	sender := &mockSender{DoFn: func(req *http.Request) (*http.Response, error) {
+		body, _ = io.ReadAll(req.Body)
+		return &http.Response{StatusCode: 204, Body: io.NopCloser(strings.NewReader(""))}, nil
+	}}
+	cfg := model.MetricsConfig{
+		Endpoints: []model.MetricsEndpoint{
+			{URL: "https://example.com", V2: &model.InfluxV2{Token: "t", Org: "o", Bucket: "b"}},
+		},
+		Timeout:     1,
+		MaxRetries:  1,
+		OmitHostTag: true,
+	}
+	Dispatch(context.Background(), sender, cfg, &model.SpeedTestResult{Timestamp: time.Unix(1, 0)})
+	if strings.Contains(string(body), "host=") {
+		t.Errorf("expected no host tag, got %q", body)
+	}
+}
+
+func TestResolveHost(t *testing.T) {
+	if h := resolveHost(model.MetricsConfig{OmitHostTag: true, HostTag: "override"}); h != "" {
+		t.Errorf("OmitHostTag should win, got %q", h)
+	}
+	if h := resolveHost(model.MetricsConfig{HostTag: "custom"}); h != "custom" {
+		t.Errorf("custom override: got %q, want %q", h, "custom")
+	}
+	// Default path calls os.Hostname(); just assert it doesn't panic.
+	// The return value is either the real hostname or "" on error, both acceptable.
+	_ = resolveHost(model.MetricsConfig{})
+}

--- a/metrics/encode.go
+++ b/metrics/encode.go
@@ -5,6 +5,7 @@ package metrics
 
 import (
 	"bytes"
+	"math"
 	"strconv"
 	"strings"
 
@@ -61,33 +62,44 @@ func writeTag(buf *bytes.Buffer, key, value string) {
 
 // writeField appends "key=value" (or ",key=value" if not first) to buf.
 // Float values are formatted with 'f' and precision -1 to preserve all
-// significant digits while avoiding scientific notation.
+// significant digits while avoiding scientific notation. Non-finite values
+// (NaN, +Inf, -Inf) are substituted with 0 because InfluxDB line protocol
+// only accepts numeric literals for float fields.
 func writeField(buf *bytes.Buffer, key string, value float64, first bool) {
 	if !first {
 		buf.WriteByte(',')
 	}
 	buf.WriteString(key)
 	buf.WriteByte('=')
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		value = 0
+	}
 	buf.WriteString(strconv.FormatFloat(value, 'f', -1, 64))
 }
 
-// escapeTagValue escapes comma, equals, and space in a tag value per the
-// InfluxDB line protocol spec. These are the only characters that require
-// escaping in tag keys, tag values, and field keys. Field keys and the
-// measurement name in this encoder are hard-coded safe constants, so this
-// helper is only called on tag values in practice.
+// escapeTagValue escapes comma, equals, space, and backslash in a tag value
+// per the InfluxDB line protocol spec, and substitutes carriage return or
+// newline with a single space because those characters cannot be escaped in
+// tag context and would otherwise split the point into multiple lines. This
+// helper is called only on tag values in practice; field keys and the
+// measurement name are hard-coded safe constants.
 func escapeTagValue(s string) string {
-	if !strings.ContainsAny(s, ",= ") {
+	if !strings.ContainsAny(s, ",= \\\n\r") {
 		return s
 	}
-	var sb bytes.Buffer
+	var sb strings.Builder
 	sb.Grow(len(s) + 4)
 	for i := 0; i < len(s); i++ {
 		c := s[i]
-		if c == ',' || c == '=' || c == ' ' {
+		switch c {
+		case '\n', '\r':
+			sb.WriteByte(' ')
+		case ',', '=', ' ', '\\':
 			sb.WriteByte('\\')
+			sb.WriteByte(c)
+		default:
+			sb.WriteByte(c)
 		}
-		sb.WriteByte(c)
 	}
 	return sb.String()
 }

--- a/metrics/encode.go
+++ b/metrics/encode.go
@@ -1,0 +1,100 @@
+// Package metrics exports speed test results to InfluxDB via HTTP line
+// protocol. The package is stateless and mirrors the shape of the notify/
+// package: pure encoder, HTTP writer with retry, top-level Dispatch.
+package metrics
+
+import (
+	"bytes"
+	"strconv"
+
+	"github.com/jkleinne/lazyspeed/model"
+)
+
+// measurement is the fixed InfluxDB measurement name for every exported
+// point. Not user-configurable to keep the schema predictable for
+// dashboards. Future additional measurements would be separate functions.
+const measurement = "lazyspeed_speedtest"
+
+// EncodePoint serializes one speed test result as a single line of InfluxDB
+// line protocol, terminated with a newline. The host parameter is the
+// already-resolved host tag value; passing an empty string omits the host
+// tag entirely (same treatment as any other empty tag value).
+//
+// Tag values that are empty on the result are omitted rather than emitted
+// with empty values, since line protocol rejects empty tag values.
+func EncodePoint(result *model.SpeedTestResult, host string) []byte {
+	var buf bytes.Buffer
+	buf.WriteString(measurement)
+
+	writeTag(&buf, "host", host)
+	writeTag(&buf, "server_name", result.ServerName)
+	writeTag(&buf, "server_sponsor", result.ServerSponsor)
+	writeTag(&buf, "country", result.Country)
+	writeTag(&buf, "user_isp", result.UserISP)
+
+	buf.WriteByte(' ')
+	writeField(&buf, "download_mbps", result.DownloadSpeed, true)
+	writeField(&buf, "upload_mbps", result.UploadSpeed, false)
+	writeField(&buf, "ping_ms", result.Ping, false)
+	writeField(&buf, "jitter_ms", result.Jitter, false)
+	writeField(&buf, "distance_km", result.Distance, false)
+
+	buf.WriteByte(' ')
+	buf.WriteString(strconv.FormatInt(result.Timestamp.UnixNano(), 10))
+	buf.WriteByte('\n')
+
+	return buf.Bytes()
+}
+
+// writeTag appends ",key=escapedValue" to buf. Empty values are skipped
+// entirely, since line protocol rejects empty tag values.
+func writeTag(buf *bytes.Buffer, key, value string) {
+	if value == "" {
+		return
+	}
+	buf.WriteByte(',')
+	buf.WriteString(key)
+	buf.WriteByte('=')
+	buf.WriteString(escapeTagValue(value))
+}
+
+// writeField appends "key=value" (or ",key=value" if not first) to buf.
+// Float values are formatted with 'f' and precision -1 to preserve all
+// significant digits while avoiding scientific notation.
+func writeField(buf *bytes.Buffer, key string, value float64, first bool) {
+	if !first {
+		buf.WriteByte(',')
+	}
+	buf.WriteString(key)
+	buf.WriteByte('=')
+	buf.WriteString(strconv.FormatFloat(value, 'f', -1, 64))
+}
+
+// escapeTagValue escapes comma, equals, and space in a tag value per the
+// InfluxDB line protocol spec. These are the only characters that require
+// escaping in tag keys, tag values, and field keys.
+func escapeTagValue(s string) string {
+	needsEscape := false
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case ',', '=', ' ':
+			needsEscape = true
+		}
+		if needsEscape {
+			break
+		}
+	}
+	if !needsEscape {
+		return s
+	}
+	var sb bytes.Buffer
+	sb.Grow(len(s) + 4)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == ',' || c == '=' || c == ' ' {
+			sb.WriteByte('\\')
+		}
+		sb.WriteByte(c)
+	}
+	return sb.String()
+}

--- a/metrics/encode.go
+++ b/metrics/encode.go
@@ -6,6 +6,7 @@ package metrics
 import (
 	"bytes"
 	"strconv"
+	"strings"
 
 	"github.com/jkleinne/lazyspeed/model"
 )
@@ -72,19 +73,11 @@ func writeField(buf *bytes.Buffer, key string, value float64, first bool) {
 
 // escapeTagValue escapes comma, equals, and space in a tag value per the
 // InfluxDB line protocol spec. These are the only characters that require
-// escaping in tag keys, tag values, and field keys.
+// escaping in tag keys, tag values, and field keys. Field keys and the
+// measurement name in this encoder are hard-coded safe constants, so this
+// helper is only called on tag values in practice.
 func escapeTagValue(s string) string {
-	needsEscape := false
-	for i := 0; i < len(s); i++ {
-		switch s[i] {
-		case ',', '=', ' ':
-			needsEscape = true
-		}
-		if needsEscape {
-			break
-		}
-	}
-	if !needsEscape {
+	if !strings.ContainsAny(s, ",= ") {
 		return s
 	}
 	var sb bytes.Buffer

--- a/metrics/encode_test.go
+++ b/metrics/encode_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"bytes"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -115,12 +116,77 @@ func TestEscapeTagValue(t *testing.T) {
 		{"with=equals", "with\\=equals"},
 		{"all three, =x", "all\\ three\\,\\ \\=x"},
 		{"", ""},
+		// Backslash escaping: input "with\backslash" → output "with\\backslash"
+		{"with\\backslash", "with\\\\backslash"},
+		// Trailing backslash: input "value\" → output "value\\"
+		{"value\\", "value\\\\"},
+		// Newline becomes space: input "line1\nline2" → output "line1 line2"
+		{"line1\nline2", "line1 line2"},
+		// CR becomes space: input "line1\rline2" → output "line1 line2"
+		{"line1\rline2", "line1 line2"},
+		// CRLF becomes two spaces: input "a\r\nb" → output "a  b"
+		{"a\r\nb", "a  b"},
+		// Mixed: input "a b\c,d=e" → output "a\ b\\c\,d\=e"
+		{"a b\\c,d=e", "a\\ b\\\\c\\,d\\=e"},
 	}
 	for _, tt := range tests {
 		got := escapeTagValue(tt.in)
 		if got != tt.want {
 			t.Errorf("escapeTagValue(%q) = %q, want %q", tt.in, got, tt.want)
 		}
+	}
+}
+
+func TestEncodePoint_SanitizesControlChars(t *testing.T) {
+	result := &model.SpeedTestResult{
+		DownloadSpeed: 100,
+		ServerName:    "line1\nline2",
+		Timestamp:     time.Unix(1, 0),
+	}
+	out := EncodePoint(result, "host")
+
+	// Count newlines: only the trailing one should exist.
+	nlCount := strings.Count(string(out), "\n")
+	if nlCount != 1 {
+		t.Errorf("expected exactly 1 newline (trailing), got %d in %q", nlCount, out)
+	}
+	// Trailing newline must be present.
+	if !strings.HasSuffix(string(out), "\n") {
+		t.Errorf("missing trailing newline: %q", out)
+	}
+	// The control char must have been substituted — verify no literal \n in the tag section.
+	tagSection := strings.TrimSuffix(string(out), "\n")
+	if strings.Contains(tagSection, "\n") {
+		t.Errorf("control char leaked into tag section: %q", out)
+	}
+}
+
+func TestEncodePoint_SubstitutesNonFiniteFloats(t *testing.T) {
+	result := &model.SpeedTestResult{
+		DownloadSpeed: math.NaN(),
+		UploadSpeed:   math.Inf(1),
+		Ping:          math.Inf(-1),
+		Jitter:        5.0,
+		Distance:      10.0,
+		Timestamp:     time.Unix(1, 0),
+	}
+	out := string(EncodePoint(result, "host"))
+
+	// None of the non-finite literals should appear.
+	for _, bad := range []string{"NaN", "+Inf", "-Inf", "Inf"} {
+		if strings.Contains(out, bad) {
+			t.Errorf("non-finite literal %q leaked into output: %q", bad, out)
+		}
+	}
+	// The substituted zeros should appear for download, upload, ping.
+	for _, want := range []string{"download_mbps=0", "upload_mbps=0", "ping_ms=0"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got %q", want, out)
+		}
+	}
+	// Finite fields should still render normally.
+	if !strings.Contains(out, "jitter_ms=5") {
+		t.Errorf("expected jitter_ms=5 in output, got %q", out)
 	}
 }
 

--- a/metrics/encode_test.go
+++ b/metrics/encode_test.go
@@ -1,0 +1,165 @@
+package metrics
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jkleinne/lazyspeed/model"
+)
+
+func TestEncodePoint_HappyPath(t *testing.T) {
+	result := &model.SpeedTestResult{
+		DownloadSpeed: 123.4,
+		UploadSpeed:   45.6,
+		Ping:          12.3,
+		Jitter:        1.2,
+		Distance:      50.0,
+		ServerName:    "Hurricane Electric",
+		ServerSponsor: "HE.net",
+		Country:       "US",
+		UserISP:       "Comcast",
+		Timestamp:     time.Unix(1712761200, 0).UTC(),
+	}
+
+	out := string(EncodePoint(result, "myhost"))
+
+	if !strings.HasPrefix(out, "lazyspeed_speedtest,") {
+		t.Errorf("missing measurement prefix: %q", out)
+	}
+
+	wantTags := []string{
+		"host=myhost",
+		"server_name=Hurricane\\ Electric",
+		"server_sponsor=HE.net",
+		"country=US",
+		"user_isp=Comcast",
+	}
+	for _, substr := range wantTags {
+		if !strings.Contains(out, substr) {
+			t.Errorf("missing tag %q in output %q", substr, out)
+		}
+	}
+
+	wantFields := []string{
+		"download_mbps=123.4",
+		"upload_mbps=45.6",
+		"ping_ms=12.3",
+		"jitter_ms=1.2",
+		"distance_km=50",
+	}
+	for _, substr := range wantFields {
+		if !strings.Contains(out, substr) {
+			t.Errorf("missing field %q in output %q", substr, out)
+		}
+	}
+
+	wantTs := "1712761200000000000"
+	if !strings.Contains(out, wantTs) {
+		t.Errorf("missing nanosecond timestamp %q in output %q", wantTs, out)
+	}
+
+	if !strings.HasSuffix(out, "\n") {
+		t.Errorf("missing trailing newline: %q", out)
+	}
+}
+
+func TestEncodePoint_OmitEmptyTags(t *testing.T) {
+	result := &model.SpeedTestResult{
+		DownloadSpeed: 100,
+		ServerName:    "server",
+		// Country, UserISP, ServerSponsor intentionally empty
+		Timestamp: time.Unix(1, 0),
+	}
+
+	out := string(EncodePoint(result, "host"))
+
+	forbidden := []string{"country=", "user_isp=", "server_sponsor="}
+	for _, s := range forbidden {
+		if strings.Contains(out, s) {
+			t.Errorf("empty tag %q leaked into output: %q", s, out)
+		}
+	}
+}
+
+func TestEncodePoint_EmptyHost(t *testing.T) {
+	result := &model.SpeedTestResult{
+		DownloadSpeed: 100,
+		Timestamp:     time.Unix(1, 0),
+	}
+	out := string(EncodePoint(result, ""))
+	if strings.Contains(out, "host=") {
+		t.Errorf("empty host leaked into output: %q", out)
+	}
+}
+
+func TestEncodePoint_CustomHost(t *testing.T) {
+	result := &model.SpeedTestResult{
+		DownloadSpeed: 100,
+		Timestamp:     time.Unix(1, 0),
+	}
+	out := string(EncodePoint(result, "node-42"))
+	if !strings.Contains(out, "host=node-42") {
+		t.Errorf("expected host=node-42, got %q", out)
+	}
+}
+
+func TestEscapeTagValue(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"simple", "simple"},
+		{"with space", "with\\ space"},
+		{"with,comma", "with\\,comma"},
+		{"with=equals", "with\\=equals"},
+		{"all three, =x", "all\\ three\\,\\ \\=x"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := escapeTagValue(tt.in)
+		if got != tt.want {
+			t.Errorf("escapeTagValue(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestEncodePoint_FloatFormattingNoScientific(t *testing.T) {
+	result := &model.SpeedTestResult{
+		DownloadSpeed: 0.000001,
+		UploadSpeed:   1234567890.0,
+		Timestamp:     time.Unix(1, 0),
+	}
+	out := string(EncodePoint(result, "h"))
+	if strings.Contains(out, "e+") || strings.Contains(out, "e-") {
+		t.Errorf("scientific notation in output: %q", out)
+	}
+}
+
+func TestEncodePoint_RoundTrip(t *testing.T) {
+	result := &model.SpeedTestResult{
+		DownloadSpeed: 100.5,
+		UploadSpeed:   50.25,
+		Ping:          10.0,
+		Jitter:        0.5,
+		Distance:      42.0,
+		// No spaces in tag values so SplitN(out, " ", 3) produces exactly
+		// three sections: measurement+tags, fields, timestamp.
+		ServerName: "TestServer",
+		Country:    "CA",
+		Timestamp:  time.Unix(1712761200, 123456789),
+	}
+	out := EncodePoint(result, "host1")
+
+	parts := bytes.SplitN(out, []byte(" "), 3)
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 space-separated sections, got %d: %q", len(parts), out)
+	}
+	if !bytes.HasPrefix(parts[0], []byte("lazyspeed_speedtest,")) {
+		t.Errorf("measurement+tags section malformed: %q", parts[0])
+	}
+	tsSection := bytes.TrimSuffix(parts[2], []byte("\n"))
+	if string(tsSection) != "1712761200123456789" {
+		t.Errorf("timestamp section: got %q, want %q", tsSection, "1712761200123456789")
+	}
+}

--- a/metrics/write.go
+++ b/metrics/write.go
@@ -35,6 +35,9 @@ type Sender interface {
 }
 
 // WriteError records a write failure for a specific endpoint.
+// URL holds the configured base URL (not the constructed write URL with
+// query parameters), so error messages name the endpoint the user
+// configured rather than leaking internal path details.
 type WriteError struct {
 	URL string
 	Err error

--- a/metrics/write.go
+++ b/metrics/write.go
@@ -52,6 +52,9 @@ func (e WriteError) Error() string {
 // failure. Network errors and 5xx are retried up to maxRetries times with
 // exponential backoff; 4xx fails permanently on the first attempt.
 func writeOne(ctx context.Context, sender Sender, ep model.MetricsEndpoint, body []byte, timeout time.Duration, maxRetries int) error {
+	if maxRetries < 1 {
+		return fmt.Errorf("maxRetries must be >= 1, got %d", maxRetries)
+	}
 	writeURL, err := buildWriteURL(ep)
 	if err != nil {
 		return fmt.Errorf("failed to build write URL: %v", err)

--- a/metrics/write.go
+++ b/metrics/write.go
@@ -1,0 +1,152 @@
+package metrics
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/jkleinne/lazyspeed/model"
+)
+
+// Retry/backoff constants for writeOne. These match the shapes defined in
+// notify/deliver.go:15-20 for webhook delivery. They are kept package-local
+// rather than shared because the two packages have independent lifecycles;
+// a future reader looking at either set should find both at once.
+const (
+	initialBackoff  = 1 * time.Second
+	backoffFactor   = 2
+	maxBackoff      = 8 * time.Second
+	contentTypeLine = "text/plain; charset=utf-8"
+	precisionQuery  = "ns"
+	suffixV1Write   = "/write"
+	suffixV2Write   = "/api/v2/write"
+)
+
+// Sender abstracts HTTP POST for testability. *http.Client satisfies this
+// interface. Mirrors notify.Sender for the same reason: keeps tests free
+// of real network I/O without taking a dependency on notify.
+type Sender interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// WriteError records a write failure for a specific endpoint.
+type WriteError struct {
+	URL string
+	Err error
+}
+
+func (e WriteError) Error() string {
+	return fmt.Sprintf("metrics %s: %v", e.URL, e.Err)
+}
+
+// writeOne sends the pre-encoded body to a single InfluxDB endpoint with
+// retry/backoff. Returns nil on success, a descriptive error on permanent
+// failure. Network errors and 5xx are retried up to maxRetries times with
+// exponential backoff; 4xx fails permanently on the first attempt.
+func writeOne(ctx context.Context, sender Sender, ep model.MetricsEndpoint, body []byte, timeout time.Duration, maxRetries int) error {
+	writeURL, err := buildWriteURL(ep)
+	if err != nil {
+		return fmt.Errorf("failed to build write URL: %v", err)
+	}
+
+	var lastErr error
+	backoff := initialBackoff
+
+	for attempt := range maxRetries {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("cancelled: %v", err)
+		}
+
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("cancelled during backoff: %v", ctx.Err())
+			case <-time.After(backoff):
+				backoff *= backoffFactor
+				if backoff > maxBackoff {
+					backoff = maxBackoff
+				}
+			}
+		}
+
+		reqCtx, reqCancel := context.WithTimeout(ctx, timeout)
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, writeURL, bytes.NewReader(body))
+		if err != nil {
+			reqCancel()
+			return fmt.Errorf("failed to create request: %v", err)
+		}
+		req.Header.Set("Content-Type", contentTypeLine)
+		applyAuth(req, ep)
+
+		resp, err := sender.Do(req)
+		if err != nil {
+			reqCancel()
+			lastErr = fmt.Errorf("request failed: %v", err)
+			continue
+		}
+
+		// Drain body before closing to allow HTTP connection reuse.
+		// Drain errors are safe to ignore: failure just means the
+		// connection won't be reused, which is a performance detail.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		reqCancel()
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return nil
+		}
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+			return fmt.Errorf("client error: status %d", resp.StatusCode)
+		}
+		lastErr = fmt.Errorf("server error: status %d", resp.StatusCode)
+	}
+	return lastErr
+}
+
+// buildWriteURL constructs the full write endpoint URL for an InfluxDB
+// endpoint. For v2, the suffix is /api/v2/write with org, bucket, and
+// precision query parameters. For v1, the suffix is /write with the db
+// query parameter. If the base URL already has a path prefix (e.g., a
+// proxied deployment), the suffix is appended to it.
+func buildWriteURL(ep model.MetricsEndpoint) (string, error) {
+	base, err := url.Parse(ep.URL)
+	if err != nil {
+		return "", fmt.Errorf("parsing base URL %q: %v", ep.URL, err)
+	}
+	q := url.Values{}
+	var suffix string
+	switch {
+	case ep.V2 != nil:
+		suffix = suffixV2Write
+		q.Set("org", ep.V2.Org)
+		q.Set("bucket", ep.V2.Bucket)
+		q.Set("precision", precisionQuery)
+	case ep.V1 != nil:
+		suffix = suffixV1Write
+		q.Set("db", ep.V1.Database)
+	default:
+		return "", fmt.Errorf("endpoint %q has neither v1 nor v2 auth set", ep.URL)
+	}
+	base.Path = strings.TrimRight(base.Path, "/") + suffix
+	base.RawQuery = q.Encode()
+	return base.String(), nil
+}
+
+// applyAuth sets the appropriate auth header on the request based on
+// which auth block is populated. v1 with no username sends no auth
+// header at all (passwordless deployments).
+func applyAuth(req *http.Request, ep model.MetricsEndpoint) {
+	switch {
+	case ep.V2 != nil:
+		req.Header.Set("Authorization", "Token "+ep.V2.Token)
+	case ep.V1 != nil:
+		if ep.V1.Username != "" {
+			req.SetBasicAuth(ep.V1.Username, ep.V1.Password)
+		}
+	}
+}

--- a/metrics/write_test.go
+++ b/metrics/write_test.go
@@ -1,0 +1,267 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jkleinne/lazyspeed/model"
+)
+
+// mockSender is a function-field test double for the Sender interface.
+type mockSender struct {
+	DoFn    func(*http.Request) (*http.Response, error)
+	Calls   int32
+	LastReq *http.Request
+}
+
+func (m *mockSender) Do(req *http.Request) (*http.Response, error) {
+	atomic.AddInt32(&m.Calls, 1)
+	m.LastReq = req
+	if m.DoFn != nil {
+		return m.DoFn(req)
+	}
+	return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(""))}, nil
+}
+
+func okResponse() *http.Response {
+	return &http.Response{StatusCode: 204, Body: io.NopCloser(strings.NewReader(""))}
+}
+
+func v2Endpoint() model.MetricsEndpoint {
+	return model.MetricsEndpoint{
+		URL: "https://example.com",
+		V2:  &model.InfluxV2{Token: "t", Org: "o", Bucket: "b"},
+	}
+}
+
+func TestWriteOne_Success2xx(t *testing.T) {
+	sender := &mockSender{DoFn: func(*http.Request) (*http.Response, error) {
+		return okResponse(), nil
+	}}
+	err := writeOne(context.Background(), sender, v2Endpoint(), []byte("line\n"), time.Second, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sender.Calls != 1 {
+		t.Errorf("expected 1 call, got %d", sender.Calls)
+	}
+}
+
+func TestWriteOne_4xxPermanent(t *testing.T) {
+	sender := &mockSender{DoFn: func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 401, Body: io.NopCloser(strings.NewReader(""))}, nil
+	}}
+	err := writeOne(context.Background(), sender, v2Endpoint(), []byte("line\n"), time.Second, 3)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if sender.Calls != 1 {
+		t.Errorf("expected exactly 1 attempt for 4xx, got %d", sender.Calls)
+	}
+}
+
+func TestWriteOne_5xxRetriedThenFails(t *testing.T) {
+	sender := &mockSender{DoFn: func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 500, Body: io.NopCloser(strings.NewReader(""))}, nil
+	}}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	err := writeOne(ctx, sender, v2Endpoint(), []byte("line\n"), time.Second, 2)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if sender.Calls != 2 {
+		t.Errorf("expected 2 attempts, got %d", sender.Calls)
+	}
+}
+
+func TestWriteOne_NetworkErrorRetried(t *testing.T) {
+	var calls int32
+	sender := &mockSender{DoFn: func(*http.Request) (*http.Response, error) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			return nil, errors.New("dial refused")
+		}
+		return okResponse(), nil
+	}}
+	err := writeOne(context.Background(), sender, v2Endpoint(), []byte("line\n"), time.Second, 3)
+	if err != nil {
+		t.Fatalf("unexpected error after retry: %v", err)
+	}
+}
+
+func TestWriteOne_ContextCancelledDuringBackoff(t *testing.T) {
+	sender := &mockSender{DoFn: func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 500, Body: io.NopCloser(strings.NewReader(""))}, nil
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	err := writeOne(ctx, sender, v2Endpoint(), []byte("line\n"), time.Second, 5)
+	if err == nil {
+		t.Fatal("expected cancelled error")
+	}
+	if !strings.Contains(err.Error(), "cancelled") {
+		t.Errorf("expected cancelled error, got %v", err)
+	}
+}
+
+func TestBuildWriteURL_V2(t *testing.T) {
+	ep := model.MetricsEndpoint{
+		URL: "https://influx.example.com:8086",
+		V2:  &model.InfluxV2{Token: "t", Org: "my-org", Bucket: "speedtest"},
+	}
+	got, err := buildWriteURL(ep)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "https://influx.example.com:8086/api/v2/write?bucket=speedtest&org=my-org&precision=ns"
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+func TestBuildWriteURL_V1(t *testing.T) {
+	ep := model.MetricsEndpoint{
+		URL: "http://localhost:8086",
+		V1:  &model.InfluxV1{Database: "lazyspeed"},
+	}
+	got, err := buildWriteURL(ep)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "http://localhost:8086/write?db=lazyspeed"
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+func TestBuildWriteURL_V2WithPathPrefix(t *testing.T) {
+	ep := model.MetricsEndpoint{
+		URL: "https://proxy.example.com/influx",
+		V2:  &model.InfluxV2{Token: "t", Org: "o", Bucket: "b"},
+	}
+	got, err := buildWriteURL(ep)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(got, "https://proxy.example.com/influx/api/v2/write") {
+		t.Errorf("path prefix lost: %q", got)
+	}
+}
+
+func TestBuildWriteURL_V2WithTrailingSlash(t *testing.T) {
+	ep := model.MetricsEndpoint{
+		URL: "https://proxy.example.com/influx/",
+		V2:  &model.InfluxV2{Token: "t", Org: "o", Bucket: "b"},
+	}
+	got, err := buildWriteURL(ep)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got, "/influx/api/v2/write") {
+		t.Errorf("double slash handling wrong: %q", got)
+	}
+	if strings.Contains(got, "//api") {
+		t.Errorf("double slash in suffix: %q", got)
+	}
+}
+
+func TestWriteOne_V2AuthHeader(t *testing.T) {
+	var seenAuth string
+	sender := &mockSender{DoFn: func(req *http.Request) (*http.Response, error) {
+		seenAuth = req.Header.Get("Authorization")
+		return okResponse(), nil
+	}}
+	ep := model.MetricsEndpoint{
+		URL: "https://example.com",
+		V2:  &model.InfluxV2{Token: "secret-token", Org: "o", Bucket: "b"},
+	}
+	if err := writeOne(context.Background(), sender, ep, []byte("line\n"), time.Second, 1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if seenAuth != "Token secret-token" {
+		t.Errorf("got auth header %q, want %q", seenAuth, "Token secret-token")
+	}
+}
+
+func TestWriteOne_V1BasicAuth(t *testing.T) {
+	var seenUser, seenPass string
+	var hadAuth bool
+	sender := &mockSender{DoFn: func(req *http.Request) (*http.Response, error) {
+		seenUser, seenPass, hadAuth = req.BasicAuth()
+		return okResponse(), nil
+	}}
+	ep := model.MetricsEndpoint{
+		URL: "http://localhost:8086",
+		V1:  &model.InfluxV1{Database: "db", Username: "admin", Password: "pw"},
+	}
+	if err := writeOne(context.Background(), sender, ep, []byte("line\n"), time.Second, 1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hadAuth {
+		t.Fatal("expected basic auth header")
+	}
+	if seenUser != "admin" || seenPass != "pw" {
+		t.Errorf("got %q/%q, want admin/pw", seenUser, seenPass)
+	}
+}
+
+func TestWriteOne_V1NoAuthWhenUsernameEmpty(t *testing.T) {
+	var hadAuth bool
+	sender := &mockSender{DoFn: func(req *http.Request) (*http.Response, error) {
+		_, _, hadAuth = req.BasicAuth()
+		return okResponse(), nil
+	}}
+	ep := model.MetricsEndpoint{
+		URL: "http://localhost:8086",
+		V1:  &model.InfluxV1{Database: "db"},
+	}
+	if err := writeOne(context.Background(), sender, ep, []byte("line\n"), time.Second, 1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hadAuth {
+		t.Error("expected no basic auth when username is empty")
+	}
+}
+
+// recordingBody tracks whether Read and Close were called. Used to verify
+// writeOne drains the response body before closing it.
+type recordingBody struct {
+	read   bool
+	closed bool
+}
+
+func (r *recordingBody) Read(p []byte) (int, error) {
+	r.read = true
+	return 0, io.EOF
+}
+
+func (r *recordingBody) Close() error {
+	r.closed = true
+	return nil
+}
+
+func TestWriteOne_DrainsBodyBeforeClose(t *testing.T) {
+	rb := &recordingBody{}
+	sender := &mockSender{DoFn: func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Body: rb}, nil
+	}}
+	if err := writeOne(context.Background(), sender, v2Endpoint(), []byte("line\n"), time.Second, 1); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rb.read {
+		t.Error("expected body to be read (drained)")
+	}
+	if !rb.closed {
+		t.Error("expected body to be closed")
+	}
+}

--- a/metrics/write_test.go
+++ b/metrics/write_test.go
@@ -240,7 +240,7 @@ type recordingBody struct {
 	closed bool
 }
 
-func (r *recordingBody) Read(p []byte) (int, error) {
+func (r *recordingBody) Read(_ []byte) (int, error) {
 	r.read = true
 	return 0, io.EOF
 }

--- a/metrics/write_test.go
+++ b/metrics/write_test.go
@@ -233,6 +233,20 @@ func TestWriteOne_V1NoAuthWhenUsernameEmpty(t *testing.T) {
 	}
 }
 
+func TestWriteOne_ZeroMaxRetriesRejected(t *testing.T) {
+	sender := &mockSender{DoFn: func(*http.Request) (*http.Response, error) {
+		t.Fatal("sender should not be called when maxRetries < 1")
+		return nil, nil
+	}}
+	err := writeOne(context.Background(), sender, v2Endpoint(), []byte("line\n"), time.Second, 0)
+	if err == nil {
+		t.Fatal("expected error for maxRetries=0, got nil")
+	}
+	if !strings.Contains(err.Error(), "maxRetries") {
+		t.Errorf("expected maxRetries in error, got %q", err.Error())
+	}
+}
+
 // recordingBody tracks whether Read and Close were called. Used to verify
 // writeOne drains the response body before closing it.
 type recordingBody struct {

--- a/model/config.go
+++ b/model/config.go
@@ -24,6 +24,9 @@ const (
 	defaultWebhookTimeout    = 10 // seconds
 	defaultWebhookMaxRetries = 1
 	maxWebhookRetries        = 5
+
+	defaultMetricsTimeout    = 10
+	defaultMetricsMaxRetries = 1
 )
 
 // HistoryConfig holds history-related configuration.
@@ -81,6 +84,42 @@ type WebhookConfig struct {
 	MaxRetries int               `yaml:"max_retries"`
 }
 
+// InfluxV1 holds InfluxDB v1 authentication fields.
+// Username and Password are optional to support passwordless deployments.
+type InfluxV1 struct {
+	Database string `yaml:"database"`
+	Username string `yaml:"username,omitempty"`
+	Password string `yaml:"password,omitempty"`
+}
+
+// InfluxV2 holds InfluxDB v2 authentication fields.
+// All three fields are required for v2 writes.
+type InfluxV2 struct {
+	Token  string `yaml:"token"`
+	Org    string `yaml:"org"`
+	Bucket string `yaml:"bucket"`
+}
+
+// MetricsEndpoint describes a single InfluxDB write target.
+// Exactly one of V1 or V2 must be set; enforced by ValidateMetricsConfig.
+type MetricsEndpoint struct {
+	URL string    `yaml:"url"`
+	V1  *InfluxV1 `yaml:"v1,omitempty"`
+	V2  *InfluxV2 `yaml:"v2,omitempty"`
+}
+
+// MetricsConfig groups outbound InfluxDB export settings.
+// HostTag is an optional literal override for the host tag value; when empty,
+// the resolver falls back to os.Hostname(). OmitHostTag, when true,
+// suppresses the host tag entirely regardless of HostTag.
+type MetricsConfig struct {
+	Endpoints   []MetricsEndpoint `yaml:"endpoints"`
+	Timeout     int               `yaml:"timeout"`
+	MaxRetries  int               `yaml:"max_retries"`
+	HostTag     string            `yaml:"host_tag,omitempty"`
+	OmitHostTag bool              `yaml:"omit_host_tag,omitempty"`
+}
+
 // Config holds all configurable options for lazyspeed.
 type Config struct {
 	History     HistoryConfig     `yaml:"history"`
@@ -89,6 +128,7 @@ type Config struct {
 	Diagnostics DiagnosticsConfig `yaml:"diagnostics"`
 	Servers     ServersConfig     `yaml:"servers"`
 	Webhooks    WebhookConfig     `yaml:"webhooks"`
+	Metrics     MetricsConfig     `yaml:"metrics"`
 }
 
 // DefaultConfig returns a Config with all defaults filled in.
@@ -113,6 +153,11 @@ func DefaultConfig() *Config {
 			Endpoints:  []WebhookEndpoint{},
 			Timeout:    defaultWebhookTimeout,
 			MaxRetries: defaultWebhookMaxRetries,
+		},
+		Metrics: MetricsConfig{
+			Endpoints:  []MetricsEndpoint{},
+			Timeout:    defaultMetricsTimeout,
+			MaxRetries: defaultMetricsMaxRetries,
 		},
 	}
 }
@@ -264,10 +309,30 @@ func LoadConfig() (*Config, error) {
 	if partial.Webhooks.MaxRetries > 0 {
 		cfg.Webhooks.MaxRetries = partial.Webhooks.MaxRetries
 	}
+	if len(partial.Metrics.Endpoints) > 0 {
+		cfg.Metrics.Endpoints = partial.Metrics.Endpoints
+	}
+	if partial.Metrics.Timeout > 0 {
+		cfg.Metrics.Timeout = partial.Metrics.Timeout
+	}
+	if partial.Metrics.MaxRetries > 0 {
+		cfg.Metrics.MaxRetries = partial.Metrics.MaxRetries
+	}
+	if partial.Metrics.HostTag != "" {
+		cfg.Metrics.HostTag = partial.Metrics.HostTag
+	}
+	if partial.Metrics.OmitHostTag {
+		cfg.Metrics.OmitHostTag = true
+	}
 
 	if len(cfg.Webhooks.Endpoints) > 0 {
 		if err := ValidateWebhookConfig(cfg.Webhooks); err != nil {
 			return nil, fmt.Errorf("invalid webhook config: %v", err)
+		}
+	}
+	if len(cfg.Metrics.Endpoints) > 0 {
+		if err := ValidateMetricsConfig(cfg.Metrics); err != nil {
+			return nil, fmt.Errorf("invalid metrics config: %v", err)
 		}
 	}
 
@@ -310,6 +375,62 @@ func ValidateWebhookConfig(cfg WebhookConfig) error {
 	}
 	if cfg.Thresholds.MaxJitter != nil && *cfg.Thresholds.MaxJitter < 0 {
 		return fmt.Errorf("webhook threshold max_jitter must be >= 0, got %f", *cfg.Thresholds.MaxJitter)
+	}
+	return nil
+}
+
+// ValidateMetricsConfig checks that a MetricsConfig is self-consistent.
+// Returns an error describing the first violation found.
+// An empty Endpoints slice is always valid (export disabled).
+func ValidateMetricsConfig(cfg MetricsConfig) error {
+	if len(cfg.Endpoints) == 0 {
+		return nil
+	}
+	for i, ep := range cfg.Endpoints {
+		if ep.URL == "" {
+			return fmt.Errorf("metrics endpoint %d has an empty URL", i)
+		}
+		parsed, err := url.Parse(ep.URL)
+		if err != nil {
+			return fmt.Errorf("metrics endpoint %d has an invalid URL %q: %v", i, ep.URL, err)
+		}
+		if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			return fmt.Errorf("metrics endpoint %d URL %q must use http or https scheme", i, ep.URL)
+		}
+
+		hasV1 := ep.V1 != nil
+		hasV2 := ep.V2 != nil
+		if !hasV1 && !hasV2 {
+			return fmt.Errorf("metrics endpoint %d has no auth block (set v1 or v2)", i)
+		}
+		if hasV1 && hasV2 {
+			return fmt.Errorf("metrics endpoint %d has both v1 and v2 set", i)
+		}
+		if hasV2 {
+			if ep.V2.Token == "" {
+				return fmt.Errorf("metrics endpoint %d v2 token is empty", i)
+			}
+			if ep.V2.Org == "" {
+				return fmt.Errorf("metrics endpoint %d v2 org is empty", i)
+			}
+			if ep.V2.Bucket == "" {
+				return fmt.Errorf("metrics endpoint %d v2 bucket is empty", i)
+			}
+		}
+		if hasV1 {
+			if ep.V1.Database == "" {
+				return fmt.Errorf("metrics endpoint %d v1 database is empty", i)
+			}
+			if ep.V1.Password != "" && ep.V1.Username == "" {
+				return fmt.Errorf("metrics endpoint %d v1 password set without username", i)
+			}
+		}
+	}
+	if cfg.Timeout <= 0 {
+		return fmt.Errorf("metrics timeout must be > 0, got %d", cfg.Timeout)
+	}
+	if cfg.MaxRetries < 1 || cfg.MaxRetries > maxWebhookRetries {
+		return fmt.Errorf("metrics max_retries must be between 1 and %d, got %d", maxWebhookRetries, cfg.MaxRetries)
 	}
 	return nil
 }

--- a/model/config.go
+++ b/model/config.go
@@ -25,7 +25,7 @@ const (
 	defaultWebhookMaxRetries = 1
 	maxWebhookRetries        = 5
 
-	defaultMetricsTimeout    = 10
+	defaultMetricsTimeout    = 10 // seconds
 	defaultMetricsMaxRetries = 1
 )
 

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -504,6 +504,266 @@ func TestValidateWebhookConfig(t *testing.T) {
 	}
 }
 
+func TestMetricsConfigDefaults(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if len(cfg.Metrics.Endpoints) != 0 {
+		t.Errorf("expected empty endpoints, got %d", len(cfg.Metrics.Endpoints))
+	}
+	if cfg.Metrics.Timeout != defaultMetricsTimeout {
+		t.Errorf("expected timeout %d, got %d", defaultMetricsTimeout, cfg.Metrics.Timeout)
+	}
+	if cfg.Metrics.MaxRetries != defaultMetricsMaxRetries {
+		t.Errorf("expected max_retries %d, got %d", defaultMetricsMaxRetries, cfg.Metrics.MaxRetries)
+	}
+	if cfg.Metrics.HostTag != "" {
+		t.Errorf("expected empty host_tag, got %q", cfg.Metrics.HostTag)
+	}
+	if cfg.Metrics.OmitHostTag {
+		t.Error("expected omit_host_tag to be false")
+	}
+}
+
+func TestValidateMetricsConfig(t *testing.T) {
+	v2ok := &InfluxV2{Token: "t", Org: "o", Bucket: "b"}
+	v1ok := &InfluxV1{Database: "db"}
+
+	tests := []struct {
+		name    string
+		cfg     MetricsConfig
+		wantErr bool
+	}{
+		{
+			name:    "empty config is valid",
+			cfg:     MetricsConfig{},
+			wantErr: false,
+		},
+		{
+			name: "valid v2 endpoint",
+			cfg: MetricsConfig{
+				Endpoints:  []MetricsEndpoint{{URL: "https://example.com", V2: v2ok}},
+				Timeout:    10,
+				MaxRetries: 1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid v1 endpoint",
+			cfg: MetricsConfig{
+				Endpoints:  []MetricsEndpoint{{URL: "http://localhost:8086", V1: v1ok}},
+				Timeout:    10,
+				MaxRetries: 1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty URL rejected",
+			cfg: MetricsConfig{
+				Endpoints:  []MetricsEndpoint{{URL: "", V2: v2ok}},
+				Timeout:    10,
+				MaxRetries: 1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "non-http scheme rejected",
+			cfg: MetricsConfig{
+				Endpoints:  []MetricsEndpoint{{URL: "ftp://example.com", V2: v2ok}},
+				Timeout:    10,
+				MaxRetries: 1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing scheme rejected",
+			cfg: MetricsConfig{
+				Endpoints:  []MetricsEndpoint{{URL: "example.com", V2: v2ok}},
+				Timeout:    10,
+				MaxRetries: 1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "neither v1 nor v2 rejected",
+			cfg: MetricsConfig{
+				Endpoints:  []MetricsEndpoint{{URL: "https://example.com"}},
+				Timeout:    10,
+				MaxRetries: 1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "both v1 and v2 rejected",
+			cfg: MetricsConfig{
+				Endpoints:  []MetricsEndpoint{{URL: "https://example.com", V1: v1ok, V2: v2ok}},
+				Timeout:    10,
+				MaxRetries: 1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "v2 missing token rejected",
+			cfg: MetricsConfig{
+				Endpoints:  []MetricsEndpoint{{URL: "https://example.com", V2: &InfluxV2{Org: "o", Bucket: "b"}}},
+				Timeout:    10,
+				MaxRetries: 1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "v2 missing org rejected",
+			cfg: MetricsConfig{
+				Endpoints:  []MetricsEndpoint{{URL: "https://example.com", V2: &InfluxV2{Token: "t", Bucket: "b"}}},
+				Timeout:    10,
+				MaxRetries: 1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "v2 missing bucket rejected",
+			cfg: MetricsConfig{
+				Endpoints:  []MetricsEndpoint{{URL: "https://example.com", V2: &InfluxV2{Token: "t", Org: "o"}}},
+				Timeout:    10,
+				MaxRetries: 1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "v1 missing database rejected",
+			cfg: MetricsConfig{
+				Endpoints:  []MetricsEndpoint{{URL: "http://localhost:8086", V1: &InfluxV1{}}},
+				Timeout:    10,
+				MaxRetries: 1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "v1 password without username rejected",
+			cfg: MetricsConfig{
+				Endpoints:  []MetricsEndpoint{{URL: "http://localhost:8086", V1: &InfluxV1{Database: "db", Password: "p"}}},
+				Timeout:    10,
+				MaxRetries: 1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "timeout zero rejected",
+			cfg: MetricsConfig{
+				Endpoints:  []MetricsEndpoint{{URL: "https://example.com", V2: v2ok}},
+				Timeout:    0,
+				MaxRetries: 1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "max_retries zero rejected",
+			cfg: MetricsConfig{
+				Endpoints:  []MetricsEndpoint{{URL: "https://example.com", V2: v2ok}},
+				Timeout:    10,
+				MaxRetries: 0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "max_retries above cap rejected",
+			cfg: MetricsConfig{
+				Endpoints:  []MetricsEndpoint{{URL: "https://example.com", V2: v2ok}},
+				Timeout:    10,
+				MaxRetries: maxWebhookRetries + 1,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMetricsConfig(tt.cfg)
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestSaveConfigWithMetrics(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	cfg := DefaultConfig()
+	cfg.Metrics = MetricsConfig{
+		Timeout:    20,
+		MaxRetries: 3,
+		HostTag:    "custom-host",
+		Endpoints: []MetricsEndpoint{
+			{
+				URL: "https://influx.example.com:8086",
+				V2: &InfluxV2{
+					Token:  "abc123",
+					Org:    "my-org",
+					Bucket: "speedtest",
+				},
+			},
+			{
+				URL: "http://localhost:8086",
+				V1: &InfluxV1{
+					Database: "lazyspeed",
+					Username: "admin",
+					Password: "secret",
+				},
+			},
+		},
+	}
+
+	if err := SaveConfig(cfg); err != nil {
+		t.Fatalf("SaveConfig failed: %v", err)
+	}
+
+	loaded, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+
+	if len(loaded.Metrics.Endpoints) != 2 {
+		t.Fatalf("expected 2 endpoints, got %d", len(loaded.Metrics.Endpoints))
+	}
+	if loaded.Metrics.Endpoints[0].V2 == nil {
+		t.Fatal("expected endpoint 0 to have V2 set")
+	}
+	if loaded.Metrics.Endpoints[0].V2.Token != "abc123" {
+		t.Errorf("token mismatch: got %q", loaded.Metrics.Endpoints[0].V2.Token)
+	}
+	if loaded.Metrics.Endpoints[0].V2.Org != "my-org" {
+		t.Errorf("org mismatch: got %q", loaded.Metrics.Endpoints[0].V2.Org)
+	}
+	if loaded.Metrics.Endpoints[0].V2.Bucket != "speedtest" {
+		t.Errorf("bucket mismatch: got %q", loaded.Metrics.Endpoints[0].V2.Bucket)
+	}
+	if loaded.Metrics.Endpoints[1].V1 == nil {
+		t.Fatal("expected endpoint 1 to have V1 set")
+	}
+	if loaded.Metrics.Endpoints[1].V1.Database != "lazyspeed" {
+		t.Errorf("database mismatch: got %q", loaded.Metrics.Endpoints[1].V1.Database)
+	}
+	if loaded.Metrics.Endpoints[1].V1.Username != "admin" {
+		t.Errorf("username mismatch: got %q", loaded.Metrics.Endpoints[1].V1.Username)
+	}
+	if loaded.Metrics.Endpoints[1].V1.Password != "secret" {
+		t.Errorf("password mismatch: got %q", loaded.Metrics.Endpoints[1].V1.Password)
+	}
+	if loaded.Metrics.Timeout != 20 {
+		t.Errorf("timeout mismatch: got %d", loaded.Metrics.Timeout)
+	}
+	if loaded.Metrics.MaxRetries != 3 {
+		t.Errorf("max_retries mismatch: got %d", loaded.Metrics.MaxRetries)
+	}
+	if loaded.Metrics.HostTag != "custom-host" {
+		t.Errorf("host_tag mismatch: got %q", loaded.Metrics.HostTag)
+	}
+}
+
 func TestSaveConfigWithWebhooks(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -510,6 +511,9 @@ func TestMetricsConfigDefaults(t *testing.T) {
 	if len(cfg.Metrics.Endpoints) != 0 {
 		t.Errorf("expected empty endpoints, got %d", len(cfg.Metrics.Endpoints))
 	}
+	if cfg.Metrics.Endpoints == nil {
+		t.Error("expected non-nil empty endpoints slice (so YAML emits an empty list, not null)")
+	}
 	if cfg.Metrics.Timeout != defaultMetricsTimeout {
 		t.Errorf("expected timeout %d, got %d", defaultMetricsTimeout, cfg.Metrics.Timeout)
 	}
@@ -529,14 +533,16 @@ func TestValidateMetricsConfig(t *testing.T) {
 	v1ok := &InfluxV1{Database: "db"}
 
 	tests := []struct {
-		name    string
-		cfg     MetricsConfig
-		wantErr bool
+		name             string
+		cfg              MetricsConfig
+		wantErr          bool
+		wantErrSubstring string
 	}{
 		{
-			name:    "empty config is valid",
-			cfg:     MetricsConfig{},
-			wantErr: false,
+			name:             "empty config is valid",
+			cfg:              MetricsConfig{},
+			wantErr:          false,
+			wantErrSubstring: "",
 		},
 		{
 			name: "valid v2 endpoint",
@@ -545,7 +551,8 @@ func TestValidateMetricsConfig(t *testing.T) {
 				Timeout:    10,
 				MaxRetries: 1,
 			},
-			wantErr: false,
+			wantErr:          false,
+			wantErrSubstring: "",
 		},
 		{
 			name: "valid v1 endpoint",
@@ -554,7 +561,8 @@ func TestValidateMetricsConfig(t *testing.T) {
 				Timeout:    10,
 				MaxRetries: 1,
 			},
-			wantErr: false,
+			wantErr:          false,
+			wantErrSubstring: "",
 		},
 		{
 			name: "empty URL rejected",
@@ -563,7 +571,8 @@ func TestValidateMetricsConfig(t *testing.T) {
 				Timeout:    10,
 				MaxRetries: 1,
 			},
-			wantErr: true,
+			wantErr:          true,
+			wantErrSubstring: "empty URL",
 		},
 		{
 			name: "non-http scheme rejected",
@@ -572,7 +581,8 @@ func TestValidateMetricsConfig(t *testing.T) {
 				Timeout:    10,
 				MaxRetries: 1,
 			},
-			wantErr: true,
+			wantErr:          true,
+			wantErrSubstring: "must use http or https scheme",
 		},
 		{
 			name: "missing scheme rejected",
@@ -581,7 +591,8 @@ func TestValidateMetricsConfig(t *testing.T) {
 				Timeout:    10,
 				MaxRetries: 1,
 			},
-			wantErr: true,
+			wantErr:          true,
+			wantErrSubstring: "must use http or https scheme",
 		},
 		{
 			name: "neither v1 nor v2 rejected",
@@ -590,7 +601,8 @@ func TestValidateMetricsConfig(t *testing.T) {
 				Timeout:    10,
 				MaxRetries: 1,
 			},
-			wantErr: true,
+			wantErr:          true,
+			wantErrSubstring: "no auth block",
 		},
 		{
 			name: "both v1 and v2 rejected",
@@ -599,7 +611,8 @@ func TestValidateMetricsConfig(t *testing.T) {
 				Timeout:    10,
 				MaxRetries: 1,
 			},
-			wantErr: true,
+			wantErr:          true,
+			wantErrSubstring: "both v1 and v2 set",
 		},
 		{
 			name: "v2 missing token rejected",
@@ -608,7 +621,8 @@ func TestValidateMetricsConfig(t *testing.T) {
 				Timeout:    10,
 				MaxRetries: 1,
 			},
-			wantErr: true,
+			wantErr:          true,
+			wantErrSubstring: "v2 token is empty",
 		},
 		{
 			name: "v2 missing org rejected",
@@ -617,7 +631,8 @@ func TestValidateMetricsConfig(t *testing.T) {
 				Timeout:    10,
 				MaxRetries: 1,
 			},
-			wantErr: true,
+			wantErr:          true,
+			wantErrSubstring: "v2 org is empty",
 		},
 		{
 			name: "v2 missing bucket rejected",
@@ -626,7 +641,8 @@ func TestValidateMetricsConfig(t *testing.T) {
 				Timeout:    10,
 				MaxRetries: 1,
 			},
-			wantErr: true,
+			wantErr:          true,
+			wantErrSubstring: "v2 bucket is empty",
 		},
 		{
 			name: "v1 missing database rejected",
@@ -635,7 +651,8 @@ func TestValidateMetricsConfig(t *testing.T) {
 				Timeout:    10,
 				MaxRetries: 1,
 			},
-			wantErr: true,
+			wantErr:          true,
+			wantErrSubstring: "v1 database is empty",
 		},
 		{
 			name: "v1 password without username rejected",
@@ -644,7 +661,8 @@ func TestValidateMetricsConfig(t *testing.T) {
 				Timeout:    10,
 				MaxRetries: 1,
 			},
-			wantErr: true,
+			wantErr:          true,
+			wantErrSubstring: "v1 password set without username",
 		},
 		{
 			name: "timeout zero rejected",
@@ -653,7 +671,8 @@ func TestValidateMetricsConfig(t *testing.T) {
 				Timeout:    0,
 				MaxRetries: 1,
 			},
-			wantErr: true,
+			wantErr:          true,
+			wantErrSubstring: "timeout must be > 0",
 		},
 		{
 			name: "max_retries zero rejected",
@@ -662,7 +681,8 @@ func TestValidateMetricsConfig(t *testing.T) {
 				Timeout:    10,
 				MaxRetries: 0,
 			},
-			wantErr: true,
+			wantErr:          true,
+			wantErrSubstring: "max_retries must be between",
 		},
 		{
 			name: "max_retries above cap rejected",
@@ -671,7 +691,8 @@ func TestValidateMetricsConfig(t *testing.T) {
 				Timeout:    10,
 				MaxRetries: maxWebhookRetries + 1,
 			},
-			wantErr: true,
+			wantErr:          true,
+			wantErrSubstring: "max_retries must be between",
 		},
 	}
 
@@ -684,6 +705,11 @@ func TestValidateMetricsConfig(t *testing.T) {
 			if !tt.wantErr && err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
+			if tt.wantErr && tt.wantErrSubstring != "" && err != nil {
+				if !strings.Contains(err.Error(), tt.wantErrSubstring) {
+					t.Errorf("error %q does not contain expected substring %q", err.Error(), tt.wantErrSubstring)
+				}
+			}
 		})
 	}
 }
@@ -694,9 +720,10 @@ func TestSaveConfigWithMetrics(t *testing.T) {
 
 	cfg := DefaultConfig()
 	cfg.Metrics = MetricsConfig{
-		Timeout:    20,
-		MaxRetries: 3,
-		HostTag:    "custom-host",
+		Timeout:     20,
+		MaxRetries:  3,
+		HostTag:     "custom-host",
+		OmitHostTag: true,
 		Endpoints: []MetricsEndpoint{
 			{
 				URL: "https://influx.example.com:8086",
@@ -761,6 +788,9 @@ func TestSaveConfigWithMetrics(t *testing.T) {
 	}
 	if loaded.Metrics.HostTag != "custom-host" {
 		t.Errorf("host_tag mismatch: got %q", loaded.Metrics.HostTag)
+	}
+	if !loaded.Metrics.OmitHostTag {
+		t.Error("expected omit_host_tag to round-trip as true")
 	}
 }
 


### PR DESCRIPTION
## Summary
Speed test results can now be pushed to InfluxDB for Grafana dashboards. Both v1 (`/write?db=X`) and v2 (`/api/v2/write?org=X&bucket=Y`) endpoints are supported, configured under a new `metrics:` block in `config.yaml`. Writes fire after every successful test in both headless and TUI modes, alongside the existing webhook dispatch. Failures log a stderr warning and never fail the test itself.

New stateless `metrics/` package mirrors the shape of `notify/`: pure encoder, HTTP writer with exponential backoff retry, top-level `Dispatch` entry point. Credentials stay in the config file (no CLI flag so tokens never hit argv). The encoder hardens the trust boundary against untrusted upstream server metadata: commas, equals, spaces, and backslashes are escaped; newlines and carriage returns are substituted with space so line protocol cannot be split mid-point; non-finite floats (NaN, Inf) are substituted with zero so InfluxDB does not reject the point.